### PR TITLE
Sort imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+lines_between_sections=1
+lines_after_imports=1
+
+multi_line_output=0
+indent='    '
+
+sections=FUTURE,STDLIB,THIRDPARTY,LOCALFOLDER
+default_section=THIRDPARTY
+
+not_skip = __init__.py

--- a/bin/dimple2ispyb.py
+++ b/bin/dimple2ispyb.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python
 
+import ConfigParser
+import logging
 import os
-import sys
 import pickle
 import pipes
-import time
 import re
-import logging
+import sys
+import time
 import traceback
-import ConfigParser
-
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
 from ispyb.dbconnection import DBConnection
 from ispyb.mxmr import mxmr
-
 
 def get_logical_arg(job, name):
     return job.args[job.args.index(name)+1]

--- a/bin/em_put_movie.py
+++ b/bin/em_put_movie.py
@@ -12,19 +12,18 @@
 
 #
 
-import string
-import logging
-from logging.handlers import RotatingFileHandler
-import time
-import os
-import sys
 import datetime
-
-from ispyb.dbconnection import DBConnection
-from ispyb.core import core
-from ispyb.mxacquisition import mxacquisition
-
+import logging
+import os
+import string
+import sys
+import time
 from datetime import datetime
+from logging.handlers import RotatingFileHandler
+
+from ispyb.core import core
+from ispyb.dbconnection import DBConnection
+from ispyb.mxacquisition import mxacquisition
 
 if __name__ == '__main__' :
 

--- a/bin/ispyb_ingester.py
+++ b/bin/ispyb_ingester.py
@@ -11,18 +11,20 @@
 # DONE
 # - logging and error handling (including logging to graylog)
 
+import logging
+import os
+import sys
+import time
 from optparse import OptionParser
+
+import ispyb.factory
+from ispyb.xmltools import mx_data_reduction_to_ispyb, xml_file_to_dict
+from workflows.transport.stomp_transport import StompTransport
+
 try:
     import configparser as ConfigParser
 except ImportError:
     import ConfigParser
-from workflows.transport.stomp_transport import StompTransport
-import time
-import sys
-import os
-import logging
-import ispyb.factory
-from ispyb.xmltools import xml_file_to_dict, mx_data_reduction_to_ispyb
 
 # Disable Python output buffering
 sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)

--- a/bin/legacy/em_put_particle.py
+++ b/bin/legacy/em_put_particle.py
@@ -7,13 +7,14 @@
 # Usage example:
 # python em_put_particle.py --movieid=1 --x=123.4 --y=50.02
 
-import cx_Oracle
-import string
 import logging
-from logging.handlers import RotatingFileHandler
-import time
 import os
+import string
 import sys
+import time
+from logging.handlers import RotatingFileHandler
+
+import cx_Oracle
 
 if __name__ == '__main__' :
 
@@ -57,4 +58,3 @@ if __name__ == '__main__' :
         
     p_id = em.put_particle(cursor, opts.particleid, opts.dcid, opts.x, opts.y)
     exit(0, "--particleid=%d" % p_id)
-    

--- a/bin/legacy/em_put_sample.py
+++ b/bin/legacy/em_put_sample.py
@@ -7,13 +7,14 @@
 # Usage example:
 # python em_put_sample.py --proposal=em1234 --x=123.4 --y=50.02
 
-import cx_Oracle
-import string
 import logging
-from logging.handlers import RotatingFileHandler
-import time
 import os
+import string
 import sys
+import time
+from logging.handlers import RotatingFileHandler
+
+import cx_Oracle
 
 if __name__ == '__main__' :
 
@@ -61,4 +62,3 @@ if __name__ == '__main__' :
         
     s_id = core.put_sample(cursor, params.values())
     exit(0, "--sampleid=%d" % s_id)
-    

--- a/bin/legacy/put_dcgroup.py
+++ b/bin/legacy/put_dcgroup.py
@@ -7,15 +7,14 @@
 # Usage example:
 # python put_dcgroup.py --movieid=1 --x=123.4 --y=50.02
 
-import cx_Oracle
-import string
 import logging
-from logging.handlers import RotatingFileHandler
-import time
 import os
+import string
 import sys
+import time
+from logging.handlers import RotatingFileHandler
 
-
+import cx_Oracle
 
 if __name__ == '__main__' :
 
@@ -86,5 +85,3 @@ if __name__ == '__main__' :
     if dcg_id is None:
         exit(1, "ERROR: dc_group is None.") # exit code 1 - indicates error
     exit(0, "--dcg_id=%d" % dcg_id)
-    
-    

--- a/bin/legacy/put_program.py
+++ b/bin/legacy/put_program.py
@@ -7,13 +7,14 @@
 # Usage example:
 # python put_program.py --....
 
-import cx_Oracle
-import string
 import logging
-from logging.handlers import RotatingFileHandler
-import time
 import os
+import string
 import sys
+import time
+from logging.handlers import RotatingFileHandler
+
+import cx_Oracle
 
 # AutoProcProgram.processingStatus: 
 # no row = didn't run
@@ -89,5 +90,3 @@ if __name__ == '__main__' :
     if p_id is None:
         exit(1, "ERROR: p_id is None.") # exit code 1 - indicates error
     exit(0, "--p_id=%d" % p_id)
-    
-    

--- a/bin/legacy/tomo2ispyb.py
+++ b/bin/legacy/tomo2ispyb.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python
 
-import os
-import sys
-import pipes
-import time
-import re
 import logging
+import os
+import pipes
+import re
+import sys
+import time
 import traceback
-
 from datetime import datetime
 
-from ispyb_api.dbconnection import dbconnection
 from ispyb_api.core import core
+from ispyb_api.dbconnection import dbconnection
 from ispyb_api.tomo import tomo
 
 def store_dc(cursor, parentid):

--- a/bin/mxdatareduction2ispyb.py
+++ b/bin/mxdatareduction2ispyb.py
@@ -8,9 +8,10 @@
 # Script to store e.g. xia2 and fast_dp results using the ispyb_api.
 #
 
-import sys
 import os
+import sys
 from datetime import datetime
+
 import ispyb.factory
 from ispyb.xmltools import mx_data_reduction_to_ispyb, xml_file_to_dict
 

--- a/docs/pipeline2ispyb.py
+++ b/docs/pipeline2ispyb.py
@@ -10,15 +10,15 @@
 # data acquisition and processing pipeline.
 #
 
-from ispyb.dbconnection import DBConnection
-from ispyb.core import core
-from ispyb.mxacquisition import mxacquisition
-from ispyb.mxscreening import mxscreening
-from ispyb.mxprocessing import mxprocessing
-from ispyb.mxmr import mxmr
-
-from datetime import datetime
 import sys
+from datetime import datetime
+
+from ispyb.core import core
+from ispyb.dbconnection import DBConnection
+from ispyb.mxacquisition import mxacquisition
+from ispyb.mxmr import mxmr
+from ispyb.mxprocessing import mxprocessing
+from ispyb.mxscreening import mxscreening
 
 conn = DBConnection.connect('dev', conf_file=sys.argv[1])
 cursor = conn.get_cursor()

--- a/ispyb/connector/mysqlsp/main.py
+++ b/ispyb/connector/mysqlsp/main.py
@@ -1,12 +1,14 @@
-import mysql.connector
-import threading
-import time
+import datetime
 import os
 import sys
-import datetime
+import threading
+import time
+
 import ispyb.interface.connection
-from ispyb.exception import ISPyBNoResultException, ISPyBWriteFailed, ISPyBRetrieveFailed
-from mysql.connector.errors import Error, DatabaseError, DataError
+import mysql.connector
+from ispyb.exception import (ISPyBNoResultException, ISPyBRetrieveFailed,
+                             ISPyBWriteFailed)
+from mysql.connector.errors import DatabaseError, DataError, Error
 
 class ISPyBMySQLSPConnector(ispyb.interface.connection.IF):
   '''Provides a connector to an ISPyB MySQL/MariaDB database through stored procedures.

--- a/ispyb/factory.py
+++ b/ispyb/factory.py
@@ -1,10 +1,11 @@
-from enum import Enum
+import codecs
 import importlib
+from enum import Enum
+
 try:
     import configparser as ConfigParser
 except ImportError:
     import ConfigParser
-import codecs
 
 class DataAreaType(Enum):
     CORE = ('Core part of the database schema', 'core', 'Core')

--- a/ispyb/interface/acquisition.py
+++ b/ispyb/interface/acquisition.py
@@ -1,4 +1,5 @@
 import abc
+
 from ispyb.interface.dataarea import DataArea
 
 class IF(DataArea):

--- a/ispyb/interface/connection.py
+++ b/ispyb/interface/connection.py
@@ -1,4 +1,5 @@
 import abc
+
 ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()}) # compatible with Python 2 *and* 3
 
 class IF(ABC):

--- a/ispyb/interface/core.py
+++ b/ispyb/interface/core.py
@@ -1,4 +1,5 @@
 import abc
+
 from ispyb.interface.dataarea import DataArea
 
 class IF(DataArea):

--- a/ispyb/interface/dataarea.py
+++ b/ispyb/interface/dataarea.py
@@ -1,4 +1,5 @@
 import abc
+
 ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()}) # compatible with Python 2 *and* 3
 
 class DataArea(ABC):

--- a/ispyb/interface/processing.py
+++ b/ispyb/interface/processing.py
@@ -1,4 +1,5 @@
 import abc
+
 from ispyb.interface.dataarea import DataArea
 
 class IF(DataArea):

--- a/ispyb/interface/screening.py
+++ b/ispyb/interface/screening.py
@@ -1,4 +1,5 @@
 import abc
+
 from ispyb.interface.dataarea import DataArea
 
 class IF(DataArea):

--- a/ispyb/interface/shipping.py
+++ b/ispyb/interface/shipping.py
@@ -1,4 +1,5 @@
 import abc
+
 from ispyb.interface.dataarea import DataArea
 
 class IF(DataArea):

--- a/ispyb/sp/acquisition.py
+++ b/ispyb/sp/acquisition.py
@@ -1,6 +1,7 @@
 import copy
-from ispyb.strictordereddict import StrictOrderedDict
+
 import ispyb.interface.acquisition
+from ispyb.strictordereddict import StrictOrderedDict
 
 class Acquisition(ispyb.interface.acquisition.IF):
   '''Acquisition provides methods to store data in the acquisition tables.'''

--- a/ispyb/sp/core.py
+++ b/ispyb/sp/core.py
@@ -7,15 +7,15 @@
 # Methods to store and retrieve data in the core tables
 #
 
-import string
-import time
-import os
-import sys
-import datetime
-from ispyb.strictordereddict import StrictOrderedDict
 import copy
+import datetime
+import os
+import string
+import sys
+import time
 
 import ispyb.interface.core
+from ispyb.strictordereddict import StrictOrderedDict
 
 class Core(ispyb.interface.core.IF):
   '''Core provides methods to store and retrieve data in the core tables.'''

--- a/ispyb/sp/emacquisition.py
+++ b/ispyb/sp/emacquisition.py
@@ -7,9 +7,10 @@
 # Methods to store EM acquisition data
 #
 
-from ispyb.strictordereddict import StrictOrderedDict
 import copy
+
 from ispyb.sp.acquisition import Acquisition
+from ispyb.strictordereddict import StrictOrderedDict
 
 class EMAcquisition(Acquisition):
     '''EMAcquisition provides methods to store data in the MotionCorrection and CTF tables.'''

--- a/ispyb/sp/mxacquisition.py
+++ b/ispyb/sp/mxacquisition.py
@@ -7,13 +7,14 @@
 # Methods to store MX acquisition data
 #
 
-import time
+import copy
+import datetime
 import os
 import sys
-import datetime
-from ispyb.strictordereddict import StrictOrderedDict
-import copy
+import time
+
 from ispyb.sp.acquisition import Acquisition
+from ispyb.strictordereddict import StrictOrderedDict
 
 class MXAcquisition(Acquisition):
   '''MXAcquisition provides methods to store data in the MX acquisition tables.'''

--- a/ispyb/sp/mxprocessing.py
+++ b/ispyb/sp/mxprocessing.py
@@ -7,13 +7,14 @@
 # Methods to store data from MX processing
 #
 
-import time
+import copy
+import datetime
 import os
 import sys
-import datetime
-import copy
-from ispyb.strictordereddict import StrictOrderedDict
+import time
+
 import ispyb.interface.processing
+from ispyb.strictordereddict import StrictOrderedDict
 
 class MXProcessing(ispyb.interface.processing.IF):
   '''MXProcessing provides methods to store MX processing data.'''

--- a/ispyb/sp/mxscreening.py
+++ b/ispyb/sp/mxscreening.py
@@ -7,13 +7,14 @@
 # Methods to store data from MX screening pipelines
 #
 
-import time
+import copy
+import datetime
 import os
 import sys
-import datetime
-import copy
-from ispyb.strictordereddict import StrictOrderedDict
+import time
+
 import ispyb.interface.screening
+from ispyb.strictordereddict import StrictOrderedDict
 
 class MXScreening(ispyb.interface.screening.IF):
   '''MXScreening provides methods to store MX characterisations and strategies.'''

--- a/ispyb/sp/shipping.py
+++ b/ispyb/sp/shipping.py
@@ -7,11 +7,12 @@
 # Methods to update data related to shipping of samples
 #
 
-import time
+import copy
+import datetime
 import os
 import sys
-import datetime
-import copy
+import time
+
 import ispyb.interface.shipping
 
 class Shipping(ispyb.interface.shipping.IF):

--- a/ispyb/xmltools.py
+++ b/ispyb/xmltools.py
@@ -1,8 +1,9 @@
 # XML-to-dict code from here:
 # http://code.activestate.com/recipes/410469-xml-as-dictionary/
 
-from ispyb.exception import ISPyBKeyProblem
 from xml.etree import ElementTree
+
+from ispyb.exception import ISPyBKeyProblem
 
 class XmlListConfig(list):
     def __init__(self, aList):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import io
 import os
 import re
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # cf.
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
-import context
 from datetime import datetime
+
+import context
 from testtools import get_core
 
 def test_upsert_sample():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
-from datetime import datetime
-import context
-from testtools import get_mxprocessing, get_mxacquisition
-from testtools import get_core
 import threading
+from datetime import datetime
+
+import context
 import ispyb.exception
+from testtools import get_core, get_mxacquisition, get_mxprocessing
 
 def test_multi_threads_upsert():
     mxprocessing = get_mxprocessing()

--- a/tests/test_mxacquisition.py
+++ b/tests/test_mxacquisition.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-import context
 from datetime import datetime
+
+import context
 from testtools import get_mxacquisition
 
 def test_mxacquisition_methods():

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-import context
 from datetime import datetime
+
+import context
 from testtools import get_mxprocessing
 
 def test_processing_jobs():

--- a/tests/test_mxscreening.py
+++ b/tests/test_mxscreening.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-import context
 from datetime import datetime
-from testtools import get_mxscreening, get_mxacquisition, get_core
+
+import context
+from testtools import get_core, get_mxacquisition, get_mxscreening
 
 def test_insert_all_screening():
     core = get_core()

--- a/tests/test_ws_connection.py
+++ b/tests/test_ws_connection.py
@@ -1,5 +1,6 @@
-import ispyb.factory
 import os
+
+import ispyb.factory
 
 def test_ws_connection():
     conf_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '../conf/ws_config.cfg'))

--- a/tests/test_xmltools.py
+++ b/tests/test_xmltools.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-import context
 import os
-from ispyb.xmltools import xml_file_to_dict, mx_data_reduction_to_ispyb
+
+import context
+from ispyb.xmltools import mx_data_reduction_to_ispyb, xml_file_to_dict
 from testtools import get_mxprocessing
 
 def test_mx_data_reduction_xml_to_ispyb():

--- a/tests/testtools.py
+++ b/tests/testtools.py
@@ -1,5 +1,6 @@
-import ispyb.factory
 import os
+
+import ispyb.factory
 
 conf_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '../conf/config.cfg'))
 


### PR DESCRIPTION
This doesn't change any code. It adds a configuration file for isort (pip install isort), which sorts imports in python files alphabetically and groups them based on internal/3rd party library.