### PR TITLE
Use RawConfigParser instead of ConfigParser.

### DIFF
--- a/ispyb/__init__.py
+++ b/ispyb/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 
 # add legacy imports to top level name space
 import ispyb.legacy.common.driver

--- a/ispyb/factory.py
+++ b/ispyb/factory.py
@@ -22,7 +22,7 @@ class DataAreaType(Enum):
         self.classname = classname
 
 def create_connection(conf_file):
-    config = ConfigParser.ConfigParser(allow_no_value=True)
+    config = ConfigParser.RawConfigParser(allow_no_value=True)
     config.readfp(codecs.open(conf_file, "r", "utf8"))
 
     section = None


### PR DESCRIPTION
Solves isues with parameters containing '%'.
RawConfigParser is already used everywhere else.

This fixes a bug we have in Zocalo/MX land.