### PR TITLE
Add ispyb.open() function

### DIFF
--- a/ispyb/__init__.py
+++ b/ispyb/__init__.py
@@ -1,6 +1,34 @@
 from __future__ import absolute_import, division, print_function
 
+try:
+  import configparser
+except ImportError:
+  import ConfigParser as configparser
+import logging
+
 __version__ = '3.2.0'
+
+_log = logging.getLogger('ispyb')
+
+def open(configuration_file):
+  '''Create an ISPyB connection using settings from a configuration file.'''
+  config = configparser.RawConfigParser(allow_no_value=True)
+  if not config.read(configuration_file):
+    raise AttributeError('No configuration found at %s' % configuration_file)
+
+  if config.has_section('ispyb_mysql_sp'):
+    from ispyb.connector.mysqlsp.main import ISPyBMySQLSPConnector as Connector
+    credentials = dict(config.items('ispyb_mysql_sp'))
+    _log.debug('Creating MySQL Stored Procedure connection from %s', configuration_file)
+    return Connector(**credentials)
+
+  if config.has_section('ispyb_ws'):
+    from ispyb.connector.ws.main import ISPyBWSConnector as Connector
+    credentials = dict(config.items('ispyb_ws'))
+    _log.debug('Creating Webservices connection from %s', configuration_file)
+    return Connector(**credentials)
+
+  raise AttributeError('No supported connection type found in %s' % configuration_file)
 
 # add legacy imports to top level name space
 import ispyb.legacy.common.driver

--- a/ispyb/factory.py
+++ b/ispyb/factory.py
@@ -1,11 +1,8 @@
-import codecs
-import importlib
-from enum import Enum
+from __future__ import absolute_import, division, print_function
 
-try:
-    import configparser as ConfigParser
-except ImportError:
-    import ConfigParser
+import importlib
+import ispyb
+from enum import Enum
 
 class DataAreaType(Enum):
     CORE = ('Core part of the database schema', 'core', 'Core')
@@ -22,27 +19,9 @@ class DataAreaType(Enum):
         self.classname = classname
 
 def create_connection(conf_file):
-    config = ConfigParser.RawConfigParser(allow_no_value=True)
-    config.readfp(codecs.open(conf_file, "r", "utf8"))
-
-    section = None
-    module_str = None
-    class_str = None
-    if config.has_section('ispyb_mysql_sp'):
-        section = 'ispyb_mysql_sp'
-        module_str = 'ispyb.connector.mysqlsp.main'
-        class_str = 'ISPyBMySQLSPConnector'
-    elif config.has_section('ispyb_ws'):
-        section = 'ispyb_ws'
-        module_str = 'ispyb.connector.ws.main'
-        class_str = 'ISPyBWSConnector'
-    else:
-        raise AttributeError('No supported connection type found in %s' % conf_file)
-
-    conn_mod = importlib.import_module(module_str)
-    ConnClass = getattr(conn_mod, class_str)
-    credentials = dict(config.items(section))
-    return ConnClass(**credentials)
+  import warnings
+  warnings.warn("deprecated, use ispyb.open()", DeprecationWarning)
+  return ispyb.open(conf_file)
 
 def create_data_area(data_area_type, conn):
   '''Factory function. Given a DataArea type and a Connection object imports the relevant data area module and


### PR DESCRIPTION
factory.create_connection() still works and calls open() in a backward-compatible manner.

This does not include the context manager bits yet, so
```with ispyb.open():```
does not work yet.