### PR TITLE
Skip database/websocket tests if no configuration file present

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+# pytest configuration file
+
+from __future__ import absolute_import, division, print_function
+
+import os
+
+import pytest
+
+@pytest.fixture
+def testconfig():
+  '''Return the path to a configuration file pointing to a test database.'''
+  config_file = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             '..', 'conf', 'config.cfg'))
+  if not os.path.exists(config_file):
+    pytest.skip("No configuration file for test database found. Skipping database tests")
+  return config_file
+
+@pytest.fixture
+def testconfig_ws():
+  '''Return the path to a configuration file pointing to a websocket
+     test instance.'''
+  config_file = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             '..', 'conf', 'ws_config.cfg'))
+  if not os.path.exists(config_file):
+    pytest.skip("No configuration file for websocket tests found. Skipping websocket tests")
+  return config_file

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,11 +1,10 @@
-from datetime import datetime
+from __future__ import division, print_function
 
 import context
-from testtools import conf_file
 import ispyb.factory
 
-def test_upsert_sample():
-    with ispyb.open(conf_file) as conn:
+def test_upsert_sample(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         params = core.get_sample_params()
         params['containerid'] = 1326
@@ -15,52 +14,52 @@ def test_upsert_sample():
         id = core.upsert_sample(list(params.values()))
         assert id is not None
 
-def test_retrieve_visit_id():
-    with ispyb.open(conf_file) as conn:
+def test_retrieve_visit_id(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         id = core.retrieve_visit_id('cm14451-2')
         assert id == 55168
 
-def test_retrieve_current_sessions():
-    with ispyb.open(conf_file) as conn:
+def test_retrieve_current_sessions(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         rs = core.retrieve_current_sessions('i03', 24*60*30000)
         assert len(rs) > 0
 
-def test_retrieve_current_sessions_for_person():
-    with ispyb.open(conf_file) as conn:
+def test_retrieve_current_sessions_for_person(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         rs = core.retrieve_current_sessions_for_person('i03', 'boaty', tolerance_mins=24*60*30000)
         assert len(rs) > 0
 
-def test_retrieve_most_recent_session():
-    with ispyb.open(conf_file) as conn:
+def test_retrieve_most_recent_session(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         rs = core.retrieve_most_recent_session('i03', 'cm')
         assert len(rs) == 1
 
-def test_retrieve_persons_for_proposal():
-    with ispyb.open(conf_file) as conn:
+def test_retrieve_persons_for_proposal(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         rs = core.retrieve_persons_for_proposal('cm', 14451)
         assert len(rs) == 1
         login = rs[0]['login']
         assert login is not None
 
-def test_retrieve_current_cm_sessions():
-    with ispyb.open(conf_file) as conn:
+def test_retrieve_current_cm_sessions(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         rs = core.retrieve_current_cm_sessions('i03')
         assert len(rs) > 0
 
-def test_retrieve_active_plates():
-    with ispyb.open(conf_file) as conn:
+def test_retrieve_active_plates(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         rs = core.retrieve_active_plates('i02-2')
         assert len(rs) >= 0
 
-def test_retrieve_proposal_title():
-    with ispyb.open(conf_file) as conn:
+def test_retrieve_proposal_title(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         title = core.retrieve_proposal_title('cm', 14451)
         assert title.strip() == 'I03 Commissioning Directory 2016'

--- a/tests/test_em_structures.py
+++ b/tests/test_em_structures.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
+from __future__ import division, print_function
 
 import context
-from testtools import conf_file
 import ispyb.factory
 
-def test_insert_motion_correction():
-    with ispyb.open(conf_file) as conn:
+def test_insert_motion_correction(testconfig):
+  with ispyb.open(testconfig) as conn:
         emacquisition = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.EMACQUISITION, conn)
         group_params = emacquisition.get_data_collection_group_params()
         group_params['parentid'] = 55168
@@ -19,8 +18,8 @@ def test_insert_motion_correction():
         motion_cor_id = emacquisition.insert_motion_correction(list(params.values()))
         assert motion_cor_id is not None
 
-def test_insert_ctf():
-    with ispyb.open(conf_file) as conn:
+def test_insert_ctf(testconfig):
+  with ispyb.open(testconfig) as conn:
         emacquisition = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.EMACQUISITION, conn)
         group_params = emacquisition.get_data_collection_group_params()
         group_params['parentid'] = 55168
@@ -39,8 +38,8 @@ def test_insert_ctf():
         ctf_id = emacquisition.insert_ctf(list(params.values()))
         assert ctf_id is not None
 
-def test_insert_drift():
-    with ispyb.open(conf_file) as conn:
+def test_insert_drift(testconfig):
+  with ispyb.open(testconfig) as conn:
         emacquisition = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.EMACQUISITION, conn)
         group_params = emacquisition.get_data_collection_group_params()
         group_params['parentid'] = 55168

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,14 +1,12 @@
-#!/usr/bin/env python
+from __future__ import division, print_function
 
 import threading
-from datetime import datetime
 
 import context
-from testtools import conf_file
 import ispyb.exception
 
-def test_multi_threads_upsert():
-    with ispyb.open(conf_file) as conn:
+def test_multi_threads_upsert(testconfig):
+  with ispyb.open(testconfig) as conn:
         mxprocessing = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXPROCESSING, conn)
 
         params = mxprocessing.get_program_params()
@@ -39,13 +37,9 @@ def test_multi_threads_upsert():
         for worker in worker_list:
             worker.join()
 
-def test_retrieve_failure():
-    with ispyb.open(conf_file) as conn:
-        mxacquisition = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXACQUISITION, conn)
+def test_retrieve_failure(testconfig):
+  with ispyb.open(testconfig) as conn:
+    mxacquisition = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXACQUISITION, conn)
 
-        try:
-            rs = mxacquisition.retrieve_data_collection_main(0)
-        except ispyb.exception.ISPyBNoResultException:
-            assert True
-        else:
-            assert False
+    with pytest.raises(ispyb.exception.ISPyBNoResultException):
+      rs = mxacquisition.retrieve_data_collection_main(0)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,6 +4,7 @@ import threading
 
 import context
 import ispyb.exception
+import pytest
 
 def test_multi_threads_upsert(testconfig):
   with ispyb.open(testconfig) as conn:

--- a/tests/test_mxacquisition.py
+++ b/tests/test_mxacquisition.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python
-
-from datetime import datetime
+from __future__ import division, print_function
 
 import context
-from testtools import conf_file
 import ispyb.factory
 
-def test_mxacquisition_methods():
-    with ispyb.open(conf_file) as conn:
+def test_mxacquisition_methods(testconfig):
+  with ispyb.open(testconfig) as conn:
         mxacquisition = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXACQUISITION, conn)
 
         params = mxacquisition.get_data_collection_group_params()

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -1,13 +1,10 @@
-#!/usr/bin/env python
-
-from datetime import datetime
+from __future__ import division, print_function
 
 import context
-from testtools import conf_file
 import ispyb.factory
 
-def test_processing_jobs():
-    with ispyb.open(conf_file) as conn:
+def test_processing_jobs(testconfig):
+  with ispyb.open(testconfig) as conn:
         mxprocessing = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXPROCESSING, conn)
 
         params = mxprocessing.get_job_params()
@@ -53,8 +50,8 @@ def test_processing_jobs():
         assert job_image_sweep[0]['endImage'] is not None
         assert job_image_sweep[0]['endImage'] == 180
 
-def test_processing():
-    with ispyb.open(conf_file) as conn:
+def test_processing(testconfig):
+  with ispyb.open(testconfig) as conn:
         mxprocessing = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXPROCESSING, conn)
 
         params = mxprocessing.get_program_params()
@@ -154,8 +151,8 @@ def test_processing():
         id = mxprocessing.upsert_quality_indicators(list(params.values()))
         assert id is not None
 
-def test_post_processing():
-    with ispyb.open(conf_file) as conn:
+def test_post_processing(testconfig):
+  with ispyb.open(testconfig) as conn:
         mxprocessing = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXPROCESSING, conn)
 
         params = mxprocessing.get_run_params()

--- a/tests/test_mxscreening.py
+++ b/tests/test_mxscreening.py
@@ -1,13 +1,12 @@
-#!/usr/bin/env python
+from __future__ import division, print_function
 
 from datetime import datetime
 
 import context
-from testtools import conf_file
 import ispyb.factory
 
-def test_insert_all_screening():
-    with ispyb.open(conf_file) as conn:
+def test_insert_all_screening(testconfig):
+  with ispyb.open(testconfig) as conn:
         core = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.CORE, conn)
         mxscreening = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXSCREENING, conn)
         mxacquisition = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXACQUISITION, conn)

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
+from __future__ import division, print_function
 
 import context
-from testtools import conf_file
 import ispyb.factory
 
-def test_update_container_assign():
-    with ispyb.open(conf_file) as conn:
+def test_update_container_assign(testconfig):
+  with ispyb.open(testconfig) as conn:
         shipping = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.SHIPPING, conn)
 
         shipping.update_container_assign('i04', 'DLS-0001', 10)

--- a/tests/test_ws_connection.py
+++ b/tests/test_ws_connection.py
@@ -1,13 +1,9 @@
-import os
+from __future__ import absolute_import, division, print_function
 
-import ispyb.factory
+import ispyb
+import pytest
 
-def test_ws_connection():
-    conf_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '../conf/ws_config.cfg'))
-    try:
-        with ispyb.open(conf_file) as conn:
-            pass
-    except NotImplementedError:
-        assert True
-    else:
-        assert False
+def test_ws_connection(testconfig_ws):
+  with pytest.raises(NotImplementedError):
+     with ispyb.open(testconfig_ws) as conn:
+        pass

--- a/tests/test_xmltools.py
+++ b/tests/test_xmltools.py
@@ -1,14 +1,13 @@
-#!/usr/bin/env python
+from __future__ import division, print_function
 
 import os
 
 import context
 from ispyb.xmltools import mx_data_reduction_to_ispyb, xml_file_to_dict
-from testtools import conf_file
 import ispyb.factory
 
-def test_mx_data_reduction_xml_to_ispyb():
-    with ispyb.open(conf_file) as conn:
+def test_mx_data_reduction_xml_to_ispyb(testconfig):
+  with ispyb.open(testconfig) as conn:
         mxprocessing = ispyb.factory.create_data_area(ispyb.factory.DataAreaType.MXPROCESSING, conn)
 
         xml_file = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data/mx_data_reduction_pipeline_results.xml'))

--- a/tests/testtools.py
+++ b/tests/testtools.py
@@ -1,3 +1,0 @@
-import os
-
-conf_file = os.path.abspath(os.path.join(os.path.dirname(__file__), '../conf/config.cfg'))


### PR DESCRIPTION
Only relevant for tests using a database/websocket backend: Use pytest fixtures to find test configuration files. If no test configuration file present then skip test with a sensible message.

Change tests that expect an exception to use ```pytest.raises()```.