### PR TITLE
Object view for ProcessingJobs

### DIFF
--- a/ispyb/interface/processing.py
+++ b/ispyb/interface/processing.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import, division, print_function
+
 import abc
 
 from ispyb.interface.dataarea import DataArea
+import ispyb.model.processingjob
 
 class IF(DataArea):
 
@@ -19,3 +22,7 @@ class IF(DataArea):
   @abc.abstractmethod
   def get_quality_indicators_params(self):
       pass
+
+  def getProcessingJob(self, jobid):
+    '''Return a ProcessingJob object representing the information about the selected processing job'''
+    return ispyb.model.processingjob.ProcessingJob(jobid, self)

--- a/ispyb/model/__init__.py
+++ b/ispyb/model/__init__.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import, division, print_function
+
+class EncapsulatedValue(object):
+  '''A helper class encapsulating another object and mostly behaving as that
+     object. The property .value allows access to the original object.
+     A list of magic methods is implemented to allow meaningful comparisons.
+  '''
+
+  def __init__(self, value):
+    '''Encapsulate an object.'''
+    self._value = value
+
+  @property
+  def value(self):
+    '''Provide read-only access to the encapsulated object'''
+    return self._value
+
+  def __getattr__(self, item):
+    '''Any undefined attribute access is passed to the encapsulated object.'''
+    return self._value.__getattr__(item)
+
+  def __getitem__(self, item):
+    '''Default item getter for iteration.'''
+    return self._value.__getitem__(item)
+
+  def __str__(self):
+    '''String coercion'''
+    return self._value.__str__()
+
+  def __eq__(self, other):
+    '''Equality operator (==)'''
+    return self._value == other
+
+  def __ne__(self, other):
+    '''Not-equals operator (!=)'''
+    return self._value != other
+
+  def __lt__(self, other):
+    '''Less-than operator (<)'''
+    return self._value < other
+
+  def __le__(self, other):
+    '''Less-than-or-equals operator (<=)'''
+    return self._value <= other
+
+  def __gt__(self, other):
+    '''Greater-than operator (>)'''
+    return self._value > other
+
+  def __ge__(self, other):
+    '''Greater-than-or-equals operator (>=)'''
+    return self._value >= other
+
+  def __bool__(self):
+    '''Python 3: value when used in bool() context.'''
+    return bool(self._value)
+
+  def __nonzero__(self):
+    '''Python 2: value when used in bool() context.'''
+    return bool(self._value)

--- a/ispyb/model/processingjob.py
+++ b/ispyb/model/processingjob.py
@@ -1,0 +1,69 @@
+from __future__ import absolute_import, division, print_function
+
+class ProcessingJob(object):
+  '''An object representing a ProcessingJob database entry. The object lazily
+     accesses the underlying database when necessary and exposes record data
+     as python attributes.
+  '''
+
+  def __init__(self, jobid, db_area):
+    '''Create a ProcessingJob object for a defined ProcessingJob ID. Requires
+       a database data area object exposing further data access methods.
+
+       :param jobid: ProcessingJob ID
+       :param db_area: ISPyB database data area object
+       :return: A ProcessingJob object representing the database entry for the
+                given job ID
+    '''
+    self._cache = None
+    self._db = db_area
+    self._jobid = jobid
+
+  def _record(self, key):
+    '''An internal caching indirector so that information is only read once
+       from the database, and only when required.'''
+    if not self._cache:
+      self._cache = self._db.retrieve_job(self._jobid)[0]
+    return self._cache[key]
+
+  @property
+  def jobid(self):
+    '''Returns the ProcessingJob ID.'''
+    return self._jobid
+
+  @property
+  def automatic(self):
+    '''Returns whether this processing job was initiated as part of automatic
+       data processing.'''
+    return bool(self._record('automatic'))
+
+  def __repr__(self):
+    '''Returns an object representation, including the processing job ID,
+       the database connection interface object, and the cache status.'''
+    return '<ProcessingJob #%d (%s), %r>' % (
+        self._jobid,
+        'cached' if self._cache else 'uncached',
+        self._db
+    )
+
+  def __str__(self):
+    '''Returns a pretty-printed object representation.'''
+    if not self._cache:
+      return 'ProcessingJob #%d (not yet loaded from database)' % self._jobid
+    return ('\n'.join((
+      'ProcessingJob #{pj.jobid}',
+      '  Name        : {pj.name}',
+      '  Recipe      : {pj.recipe}',
+      '  Comments    : {pj.comment}',
+      '  Primary DCID: {pj.DCID}',
+      '  Timestamp   : {pj.timestamp}',
+    ))).format(pj=self)
+
+for key, internalkey in (
+    ('DCID', 'dataCollectionId'),
+    ('name', 'displayName'),
+    ('comment', 'comments'),
+    ('recipe', 'recipe'),
+    ('timestamp', 'recordTimestamp'),
+  ):
+  setattr(ProcessingJob, key, property(lambda self, k=internalkey: self._record(k)))

--- a/ispyb/model/processingjob.py
+++ b/ispyb/model/processingjob.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
+import collections
+
+import ispyb.model
+
 class ProcessingJob(object):
   '''An object representing a ProcessingJob database entry. The object lazily
      accesses the underlying database when necessary and exposes record data
@@ -16,6 +20,7 @@ class ProcessingJob(object):
                 specified job ID
     '''
     self._cache = None
+    self._cache_parameters = None
     self._db = db_area
     self._jobid = jobid
 
@@ -44,6 +49,12 @@ class ProcessingJob(object):
     '''Returns whether this processing job was initiated as part of automatic
        data processing.'''
     return bool(self._record('automatic'))
+
+  @property
+  def parameters(self):
+    if not self._cache_parameters:
+      self._cache_parameters = ProcessingJobParameters(self._jobid, self._db)
+    return self._cache_parameters
 
   def __repr__(self):
     '''Returns an object representation, including the processing job ID,
@@ -74,3 +85,80 @@ for key, internalkey in (
     ('timestamp', 'recordTimestamp'),
   ):
   setattr(ProcessingJob, key, property(lambda self, k=internalkey: self._record(k)))
+
+
+class ProcessingJobParameterValue(ispyb.model.EncapsulatedValue):
+  '''An object representing a key/value parameter pair. The object behaves like
+     the value string, but also contains a .key and .parameter_id attribute.
+  '''
+
+  def __init__(self, key, value, parameter_id):
+    ispyb.model.EncapsulatedValue.__init__(self, value)
+    self._key, self._pid = key, parameter_id
+
+  @property
+  def key(self):
+    '''Returns the parameterKey'''
+    return self._key
+
+  @property
+  def parameter_id(self):
+    '''Returns the processingJobParameterId'''
+    return self._pid
+
+  def __repr__(self):
+    '''Returns an object representation, including the processing job parameter
+       key, value, and ID.'''
+    return "ProcessingJobParameterValue(key:%r, value:%r, id:%r)" % \
+        (self._key, self._value, self._pid)
+
+
+class ProcessingJobParameters(object):
+  '''An object representing the parameters for a ProcessingJob database entry.
+     The object lazily accesses the underlying database when necessary and
+     exposes the parameters both as a list and in a dictionary-like fashion.
+  '''
+
+  def __init__(self, jobid, db_area):
+    '''Create a ProcessingJobParameters object for a defined ProcessingJob ID.
+       Requires a database data area object exposing further data access
+       methods.
+
+       :param jobid: ProcessingJob ID
+       :param db_area: ISPyB database data area object
+       :return: A ProcessingJobParameters object representing the database
+                entry for the parameters of the specified job ID
+    '''
+    self._cache = None
+    self._db = db_area
+    self._jobid = jobid
+
+  def _record(self):
+    '''An internal caching indirector so that information is only read once
+       from the database, and only when required.'''
+    if self._cache is None:
+      self._cache = [
+          (p['parameterKey'], ProcessingJobParameterValue(
+               p['parameterKey'], p['parameterValue'], p['parameterId']))
+          for p in self._db.retrieve_job_parameters(self._jobid)
+      ]
+      self._cache_dict = collections.OrderedDict(self._cache)
+    return self._cache
+
+  def __getitem__(self, item):
+    '''Allow accessing the parameter records as a list or dictionary.'''
+    try:
+      # Assume 'item' is an integer: treat as list
+      return self._record()[item]
+    except TypeError:
+      # Assume 'item' is a key: treat as dictionary
+      return self._cache_dict[item]
+
+  def __repr__(self):
+    '''Returns an object representation, including the processing job ID,
+       the database connection interface object, and the cache status.'''
+    return '<ProcessingJobParameters #%d (%s), %r>' % (
+        self._jobid,
+        'cached' if self._cache is None else 'uncached',
+        self._db
+    )

--- a/ispyb/model/processingjob.py
+++ b/ispyb/model/processingjob.py
@@ -13,7 +13,7 @@ class ProcessingJob(object):
        :param jobid: ProcessingJob ID
        :param db_area: ISPyB database data area object
        :return: A ProcessingJob object representing the database entry for the
-                given job ID
+                specified job ID
     '''
     self._cache = None
     self._db = db_area
@@ -25,6 +25,14 @@ class ProcessingJob(object):
     if not self._cache:
       self._cache = self._db.retrieve_job(self._jobid)[0]
     return self._cache[key]
+
+  @property
+  def DCID(self):
+    '''Returns the data collection id.'''
+    dcid = self._record('dataCollectionId')
+    if dcid is None:
+      return None
+    return int(dcid)
 
   @property
   def jobid(self):
@@ -60,7 +68,6 @@ class ProcessingJob(object):
     ))).format(pj=self)
 
 for key, internalkey in (
-    ('DCID', 'dataCollectionId'),
     ('name', 'displayName'),
     ('comment', 'comments'),
     ('recipe', 'recipe'),

--- a/tests/model/test_encapsulation.py
+++ b/tests/model/test_encapsulation.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import, division, print_function
+
+import ispyb.model
+import pytest
+
+@pytest.mark.parametrize('thing', ['string', u'unicode', '', u''])
+def test_encapsulated_string_behaves_as_string(thing):
+  e = ispyb.model.EncapsulatedValue(thing)
+  assert e is not thing
+  assert e.value is thing
+
+  assert (e == thing) is True
+  assert (e != thing) is False
+  assert (e < thing) is False
+  assert (e > thing) is False
+  assert (e <= thing) is True
+  assert (e >= thing) is True
+  assert bool(e) == bool(thing)
+
+  assert str(e) == str(thing)
+  assert repr(e) != repr(thing)
+  assert list(e) == list(thing)
+
+  for comparison in ('strinf', 'string', 'strinh', u'unicodd', u'unicode', u'unicodf'):
+    assert (e == comparison) is (thing == comparison)
+    assert (e <= comparison) is (thing <= comparison)
+    assert (e >= comparison) is (thing >= comparison)
+    assert (e < comparison) is (thing < comparison)
+    assert (e > comparison) is (thing > comparison)
+
+@pytest.mark.parametrize('thing', [0, 2])
+def test_encapsulated_number_behaves_as_number(thing):
+  e = ispyb.model.EncapsulatedValue(thing)
+  assert e is not thing
+  assert e.value is thing
+
+  assert (e == thing) is True
+  assert (e != thing) is False
+  assert (e < thing) is False
+  assert (e > thing) is False
+  assert (e <= thing) is True
+  assert (e >= thing) is True
+  assert bool(e) == bool(thing)
+
+  assert str(e) == str(thing)
+  assert repr(e) != repr(thing)
+
+  with pytest.raises(AttributeError):
+    list(e)
+
+  for comparison in (-1, 0, 1, 2, 3):
+    assert (e == comparison) is (thing == comparison)
+    assert (e <= comparison) is (thing <= comparison)
+    assert (e >= comparison) is (thing >= comparison)
+    assert (e < comparison) is (thing < comparison)
+    assert (e > comparison) is (thing > comparison)

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -50,6 +50,10 @@ def test_processing_jobs(testconfig):
         assert job_image_sweep[0]['endImage'] is not None
         assert job_image_sweep[0]['endImage'] == 180
 
+        job = mxprocessing.getProcessingJob(job_id)
+        assert job.name
+        assert job.DCID
+
 def test_processing(testconfig):
   with ispyb.open(testconfig) as conn:
         mxprocessing = conn.mx_processing

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -61,6 +61,12 @@ def test_processing_jobs(testconfig):
         assert job.parameters['fudge factor'] == '3.14'
         assert job.parameters['fudge factor'].parameter_id == job_parameter_id
 
+        assert len(job.sweeps) == 1
+        assert job.sweeps[0].start == 1
+        assert job.sweeps[0].end == 180
+        assert job.sweeps[0].DCID == 993677
+        assert job.sweeps[0].sweep_id == id
+
 def test_processing(testconfig):
   with ispyb.open(testconfig) as conn:
         mxprocessing = conn.mx_processing

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -56,6 +56,11 @@ def test_processing_jobs(testconfig):
         assert job.recipe == 'xia2 recipe 14'
         assert job.timestamp
 
+        assert list(job.parameters) == [ ('fudge factor', '3.14') ]
+        assert dict(job.parameters) == { 'fudge factor': '3.14' }
+        assert job.parameters['fudge factor'] == '3.14'
+        assert job.parameters['fudge factor'].parameter_id == job_parameter_id
+
 def test_processing(testconfig):
   with ispyb.open(testconfig) as conn:
         mxprocessing = conn.mx_processing

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -39,20 +39,22 @@ def test_processing_jobs(testconfig):
         assert job[0]['dataCollectionId'] is not None
 
         job_params = mxprocessing.retrieve_job_parameters(job_id)
-        assert job_params[0]['parameterKey'] is not None
         assert job_params[0]['parameterKey'] == 'fudge factor'
-        assert job_params[0]['parameterValue'] is not None
         assert job_params[0]['parameterValue'] == '3.14'
 
         job_image_sweep = mxprocessing.retrieve_job_image_sweeps(job_id)
-        assert job_image_sweep[0]['startImage'] is not None
         assert job_image_sweep[0]['startImage'] == 1
-        assert job_image_sweep[0]['endImage'] is not None
         assert job_image_sweep[0]['endImage'] == 180
 
+        # Retrieve same information via object model
+
         job = mxprocessing.getProcessingJob(job_id)
-        assert job.name
-        assert job.DCID
+        assert job.name == 'test_job'
+        assert job.DCID == 993677
+        assert job.comment == 'Test job by the unit test system ...'
+        assert job.automatic is False
+        assert job.recipe == 'xia2 recipe 14'
+        assert job.timestamp
 
 def test_processing(testconfig):
   with ispyb.open(testconfig) as conn:


### PR DESCRIPTION
I have implemented an example object model for the ProcessingJob tables.

With this you can now do the following:
```python
with ispyb.open(config) as i:
  job = i.mx_processing.getProcessingJob(16156)

  print job.name
# "Xia2 DIALS"

  print job.comment
# None

  print job
# ProcessingJob #16165
#  Name        : Xia2 DIALS
#  Recipe      : xia2-dials
#  Comments    : None
#  Primary DCID: 2596045
#  Timestamp   : 2018-06-07 13:06:05

  print job.parameters['spacegroup']
# P6322
  print job.parameters['spacegroup'].parameter_id
# 12502

  print len(job.sweeps)
# 1
  print job.sweeps[0].start, job.sweeps[0].end
# 1 3600
```

Database lookups happen only when required, results are cached. The model object runs on the data area interface, which makes it independent on the underlying data storage model. So it works with stored procedures as well as, say, web services.