### PR TITLE
object models for AutoProcProgram and DataCollection

### DIFF
--- a/ispyb/__init__.py
+++ b/ispyb/__init__.py
@@ -6,7 +6,7 @@ except ImportError:
   import ConfigParser as configparser
 import logging
 
-__version__ = '4.7.1'
+__version__ = '4.8.0'
 
 _log = logging.getLogger('ispyb')
 

--- a/ispyb/interface/acquisition.py
+++ b/ispyb/interface/acquisition.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import, division, print_function
+
 import abc
 
 from ispyb.interface.dataarea import DataArea
+import ispyb.model.datacollection
 
 class IF(DataArea):
 
@@ -21,3 +24,8 @@ class IF(DataArea):
   def upsert_data_collection(self, cursor, values):
     '''Store new data collection.'''
     pass
+
+  def get_data_collection(self, dcid):
+    '''Return a DataCollection object representing the information about the
+       selected data collection'''
+    return ispyb.model.datacollection.DataCollection(dcid, self)

--- a/ispyb/interface/processing.py
+++ b/ispyb/interface/processing.py
@@ -23,6 +23,6 @@ class IF(DataArea):
   def get_quality_indicators_params(self):
       pass
 
-  def getProcessingJob(self, jobid):
+  def get_processing_job(self, jobid):
     '''Return a ProcessingJob object representing the information about the selected processing job'''
     return ispyb.model.processingjob.ProcessingJob(jobid, self)

--- a/ispyb/model/__init__.py
+++ b/ispyb/model/__init__.py
@@ -1,5 +1,41 @@
 from __future__ import absolute_import, division, print_function
 
+class DBCache(object):
+  '''A helper class with useful functions to manage caching of database
+     requests.
+     Subclasses must implement reload() which should store data to be cached
+     in self._data. Cached data should be accessed as self._data. On first
+     uncached access reload() is called.'''
+
+  def __init__(self):
+    '''Data has not yet been loaded from the database.'''
+
+  def load(self):
+    '''Ensure data is loaded from the database.'''
+    if not self.cached:
+      self.reload()
+
+  def reload(self):
+    '''Force update from the database.'''
+    raise NotImplementedError()
+
+  @property
+  def _data(self):
+    '''Internal caching logic so that information is only read once from the
+       database, and only when required.'''
+    if not hasattr(self, '_data_cache'):
+      self.reload()
+    return getattr(self, '_data_cache')
+
+  @_data.setter
+  def _data(self, value):
+    setattr(self, '_data_cache', value)
+
+  @property
+  def cached(self):
+    return hasattr(self, '_data_cache')
+
+
 class EncapsulatedValue(object):
   '''A helper class encapsulating another object and mostly behaving as that
      object. The property .value allows access to the original object.

--- a/ispyb/model/autoprocprogram.py
+++ b/ispyb/model/autoprocprogram.py
@@ -68,9 +68,9 @@ class AutoProcProgram(ispyb.model.DBCache):
       '  Command      : {0.command}',
       '  Environment  : {0.environment}',
       '  ProcessingJob: {0.jobid}',
-      '  Defined      : {0.timestamp}',
-      '  Started      : {0.start}',
-      '  Last Update  : {0.end}',
+      '  Defined      : {0.time_defined}',
+      '  Started      : {0.time_start}',
+      '  Last Update  : {0.time_end}',
       '  Last Message : {0.message}',
     ))).format(self)
 
@@ -78,9 +78,9 @@ for key, internalkey in (
     ('program', 'programs'),
     ('command', 'commandLine'),
     ('environment', 'environment'),
-    ('timestamp', 'recordTimeStamp'),
-    ('start', 'startTime'),
-    ('end', 'endTime'),
+    ('time_defined', 'recordTimeStamp'),
+    ('time_start', 'startTime'),
+    ('time_end', 'endTime'),
     ('status', 'status'),
     ('message', 'message'),
   ):

--- a/ispyb/model/autoprocprogram.py
+++ b/ispyb/model/autoprocprogram.py
@@ -38,12 +38,11 @@ class AutoProcProgram(ispyb.model.DBCache):
     return self._data['jobId']
 
   @property
-  def status(self):
+  def status_text(self):
     '''Returns a human-readable status.'''
-    return "(Status unknown: SCI-7444)" # TODO
-    if self._data['processingStatus'] == 1:
+    if self._data['status'] == 1:
       return 'success'
-    if self._data['processingStatus'] == 0:
+    if self._data['status'] == 0:
       return 'failure'
     if self._data['startTime']:
       return 'running'
@@ -65,6 +64,7 @@ class AutoProcProgram(ispyb.model.DBCache):
     return ('\n'.join((
       'AutoProcProgram #{0.appid}',
       '  Name         : {0.program}',
+      '  Status       : {0.status_text}',
       '  Command      : {0.command}',
       '  Environment  : {0.environment}',
       '  ProcessingJob: {0.jobid}',
@@ -81,6 +81,7 @@ for key, internalkey in (
     ('timestamp', 'recordTimeStamp'),
     ('start', 'startTime'),
     ('end', 'endTime'),
+    ('status', 'status'),
     ('message', 'message'),
   ):
   setattr(AutoProcProgram, key, property(lambda self, k=internalkey: self._data[k]))

--- a/ispyb/model/autoprocprogram.py
+++ b/ispyb/model/autoprocprogram.py
@@ -1,0 +1,86 @@
+from __future__ import absolute_import, division, print_function
+
+import ispyb.model
+
+class AutoProcProgram(ispyb.model.DBCache):
+  '''An object representing an AutoProcProgram database entry. The object
+     lazily accesses the underlying database when necessary and exposes record
+     data as python attributes.
+  '''
+
+  def __init__(self, appid, db_area, preload=None):
+    '''Create an AutoProcProgram object for a defined APPID. Requires
+       a database data area object exposing further data access methods.
+
+       :param appid: AutoProcProgramID
+       :param db_area: ISPyB database data area object
+       :return: An AutoProcProgram object representing the database entry for
+                the specified job AutoProcProgramID
+    '''
+    self._db = db_area
+    self._appid = int(appid)
+    if preload:
+      self._data = preload
+
+  def reload(self):
+    '''Load/update information from the database.'''
+    raise NotImplementedError("Don't know the API call for this")
+#   self._data = self._db.retrieve_job(self._appid)[0]
+
+  @property
+  def appid(self):
+    '''Returns the AutoProcProgramID.'''
+    return self._appid
+
+  @property
+  def jobid(self):
+    '''Returns the associated ProcessingJob ID (if any).'''
+    return self._data['jobId']
+
+  @property
+  def status(self):
+    '''Returns a human-readable status.'''
+    return "(Status unknown: SCI-7444)" # TODO
+    if self._data['processingStatus'] == 1:
+      return 'success'
+    if self._data['processingStatus'] == 0:
+      return 'failure'
+    if self._data['startTime']:
+      return 'running'
+    return 'queued'
+
+  def __repr__(self):
+    '''Returns an object representation, including the AutoProcProgramID,
+       the database connection interface object, and the cache status.'''
+    return '<AutoProcProgram #%d (%s), %r>' % (
+        self._appid,
+        'cached' if self.cached else 'uncached',
+        self._db
+    )
+
+  def __str__(self):
+    '''Returns a pretty-printed object representation.'''
+    if not self.cached:
+      return 'AutoProcProgram #%d (not yet loaded from database)' % self._appid
+    return ('\n'.join((
+      'AutoProcProgram #{0.appid}',
+      '  Name         : {0.program}',
+      '  Command      : {0.command}',
+      '  Environment  : {0.environment}',
+      '  ProcessingJob: {0.jobid}',
+      '  Defined      : {0.timestamp}',
+      '  Started      : {0.start}',
+      '  Last Update  : {0.end}',
+      '  Last Message : {0.message}',
+    ))).format(self)
+
+for key, internalkey in (
+    ('program', 'programs'),
+    ('command', 'commandLine'),
+    ('environment', 'environment'),
+    ('timestamp', 'recordTimeStamp'),
+    ('start', 'startTime'),
+    ('end', 'endTime'),
+    ('message', 'message'),
+  ):
+  setattr(AutoProcProgram, key, property(lambda self, k=internalkey: self._data[k]))

--- a/ispyb/model/datacollection.py
+++ b/ispyb/model/datacollection.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import, division, print_function
+
+import ispyb.model
+
+class DataCollection(ispyb.model.DBCache):
+  '''An object representing a DataCollection database entry. The object
+     lazily accesses the underlying database when necessary and exposes record
+     data as python attributes.
+  '''
+
+  def __init__(self, dcid, db_area, preload=None):
+    '''Create a DataCollection object for a defined DCID. Requires
+       a database data area object exposing further data access methods.
+
+       :param dcid: DataCollectionID
+       :param db_area: ISPyB database data area object
+       :return: A DataCollection object representing the database entry for
+                the specified DataCollectionID
+    '''
+    self._db = db_area
+    self._dcid = int(dcid)
+    if preload:
+      self._data = preload
+
+  def reload(self):
+    '''Load/update information from the database.'''
+    self._data = self._db.retrieve_data_collection_main(self._dcid)[0]
+
+  @property
+  def dcid(self):
+    '''Returns the DataCollectionID.'''
+    return self._dcid
+
+  def __repr__(self):
+    '''Returns an object representation, including the DataCollectionID,
+       the database connection interface object, and the cache status.'''
+    return '<DataCollection #%d (%s), %r>' % (
+        self._dcid,
+        'cached' if self.cached else 'uncached',
+        self._db
+    )
+
+  def __str__(self):
+    '''Returns a pretty-printed object representation.'''
+    if not self.cached:
+      return 'DataCollection #%d (not yet loaded from database)' % self._dcid
+    return ('\n'.join((
+      'DataCollection #{0.dcid}',
+      '  Started      : {0.time_start}',
+      '  Finished     : {0.time_end}',
+    ))).format(self)
+
+for key, internalkey in (
+    ('time_start', 'startTime'),
+    ('time_end', 'endTime'),
+    ('image_count', 'noImages'),
+    ('image_start_number', 'startImgNumber'),
+  ):
+  setattr(DataCollection, key, property(lambda self, k=internalkey: self._data[k]))

--- a/tests/model/test_datacollection.py
+++ b/tests/model/test_datacollection.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import, division, print_function
+
+import ispyb.model.datacollection
+import mock
+import pytest
+
+def test_datacollection_model_retrieves_database_records():
+  db, record = mock.Mock(), mock.Mock()
+  db.retrieve_data_collection_main.return_value = [record]
+
+  dc = ispyb.model.datacollection.DataCollection(1234, db)
+  assert not db.retrieve_data_collection_main.called
+  assert '1234' in str(dc)
+  assert '1234' in repr(dc)
+  assert 'uncached' in repr(dc)
+
+  dc.load()
+  db.retrieve_data_collection_main.assert_called_once_with(1234)
+  assert dc._data == record
+  assert '1234' in repr(dc)
+  assert 'cached' in repr(dc) and 'uncached' not in repr(dc)
+
+  # Test caching behaviour
+  dc.load()
+  db.retrieve_data_collection_main.assert_called_once()
+
+
+def test_datacollection_model_accepts_preloading():
+  db, record = mock.Mock(), mock.Mock()
+
+  dc = ispyb.model.datacollection.DataCollection(1234, db, preload=record)
+  assert dc._data == record
+
+  dc.load()
+  assert not db.retrieve_data_collection_main.called
+
+
+database_column_to_attribute_name = {
+    "groupId": None,
+    "detectorId": None,
+    "blSubSampleId": None,
+    "dcNumber": None,
+    "startTime": "time_start",
+    "endTime": "time_end",
+    "status": None,
+    "noImages": "image_count",
+    "startImgNumber": "image_start_number",
+    "noPasses": None,
+    "imgDir": None,
+    "imgPrefix": None,
+    "imgSuffix": None,
+    "fileTemplate": None,
+    "snapshot1": None,
+    "snapshot2": None,
+    "snapshot3": None,
+    "snapshot4": None,
+    "comments": None,
+}
+record = {
+    k: getattr(mock.sentinel, k)
+    for k in database_column_to_attribute_name
+}
+
+@pytest.mark.parametrize('column,attribute', filter(lambda ca: ca[1], database_column_to_attribute_name.items()))
+def test_datacollection_model_attributes_return_correct_values(column, attribute):
+  dc = ispyb.model.datacollection.DataCollection(1234, None, preload=record)
+  assert getattr(dc, attribute) == record[column]
+
+@pytest.mark.parametrize('printed_attribute', ('startTime', 'endTime'))
+def test_pretty_printing_datacollection_shows_attribute(printed_attribute):
+  dc_str = str(ispyb.model.datacollection.DataCollection(1234, None, preload=record))
+  assert "1234" in dc_str
+  assert str(record[printed_attribute]) in dc_str

--- a/tests/model/test_dbcache.py
+++ b/tests/model/test_dbcache.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import, division, print_function
+
+import mock
+import ispyb.model
+import pytest
+
+def test_empty_dbcache_remains_empty():
+  cache = ispyb.model.DBCache()
+
+  assert cache.cached == False
+
+  with pytest.raises(NotImplementedError):
+    cache.load()
+  with pytest.raises(NotImplementedError):
+    cache.reload()
+
+  assert cache.cached == False
+
+def test_dbcache_caching_logic_using_load():
+  load_counter = mock.Mock()
+  def reload_function():
+    load_counter()
+    cache._data = mock.sentinel.data
+
+  # Create a cache object instance
+  cache = ispyb.model.DBCache()
+  # "implement" the reload function
+  setattr(cache, 'reload', reload_function)
+
+  # To begin with the cache is empty
+  assert cache.cached == False
+  assert load_counter.call_count == 0
+
+  cache.load()
+  assert cache.cached == True
+  assert load_counter.call_count == 1
+  assert cache._data == mock.sentinel.data
+
+  cache.load() # No reload should happen here
+  assert cache.cached == True
+  assert load_counter.call_count == 1
+  assert cache._data == mock.sentinel.data
+
+  cache.reload() # Reload should happen here
+  assert cache.cached == True
+  assert load_counter.call_count == 2
+  assert cache._data == mock.sentinel.data
+
+def test_dbcache_caching_logic_using_data_access():
+  load_counter = mock.Mock()
+  def reload_function():
+    load_counter()
+    cache._data = mock.sentinel.data
+
+  # Create a cache object instance
+  cache = ispyb.model.DBCache()
+  # "implement" the reload function
+  setattr(cache, 'reload', reload_function)
+
+  # To begin with the cache is empty
+  assert cache.cached == False
+  assert load_counter.call_count == 0
+
+  assert cache._data == mock.sentinel.data # implicitly calls reload()
+
+  assert cache.cached == True
+  assert load_counter.call_count == 1
+
+  assert cache._data == mock.sentinel.data # No reload should happen here
+
+  assert cache.cached == True
+  assert load_counter.call_count == 1

--- a/tests/test_mxacquisition.py
+++ b/tests/test_mxacquisition.py
@@ -37,6 +37,9 @@ def test_mxacquisition_methods(testconfig):
         rs = mxacquisition.retrieve_data_collection_main(id1)
         assert rs[0]['groupId'] == dcgid
 
+        dc = mxacquisition.get_data_collection(id1)
+        assert dc.image_count == 360
+
         params = mxacquisition.get_image_params()
         params['parentid'] = id1
         params['img_number'] = 1

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -83,6 +83,17 @@ def test_processing(testconfig):
         assert rs is not None
         assert len(rs) > 0
 
+        # Find program using the processing job ID and verify stored values
+        programs = mxprocessing.getProcessingJob(5).programs
+        assert programs
+        assert len(programs) >= 1
+        programs = list(filter(lambda p: p.appid == id, programs))
+        assert programs
+        program = programs[0]
+        assert program.jobid == 5
+        assert program.command == params['cmd_line']
+        assert program.message == params['message']
+
         params['id'] = id
         params['status'] = True
         params['message'] = 'Finished'

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -48,7 +48,7 @@ def test_processing_jobs(testconfig):
 
         # Retrieve same information via object model
 
-        job = mxprocessing.getProcessingJob(job_id)
+        job = mxprocessing.get_processing_job(job_id)
         assert job.name == 'test_job'
         assert job.DCID == 993677
         assert job.comment == 'Test job by the unit test system ...'
@@ -84,7 +84,7 @@ def test_processing(testconfig):
         assert len(rs) > 0
 
         # Find program using the processing job ID and verify stored values
-        programs = mxprocessing.getProcessingJob(5).programs
+        programs = mxprocessing.get_processing_job(5).programs
         assert programs
         assert len(programs) >= 1
         programs = list(filter(lambda p: p.appid == id, programs))


### PR DESCRIPTION
* Add models for AutoProcProgram and DataCollection
* AutoProcProgram can be accessed via ```ProcessingJob().programs```
* DataCollection can be accessed via ```i.mx_acquisition.get_data_collection(dcid)```
* ```DataCollection()``` only exposes a few fields at this time. More to come later.
* Rename ```i.mx_processing.getProcessingJob(pjid)``` to ```.i.mx_processing.get_processing_job(pjid)```
* Bump version to 4.8.0