### PR TITLE
Enable GridInfo model object for developers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,3 +30,10 @@ ProcessingJob
 .. automodule:: ispyb.model.processingjob
     :members:
 
+ProcessingProgram
+=================
+
+These objects correspond to entries in the ISPyB table AutoProcProgram.
+
+.. automodule:: ispyb.model.processingprogram
+    :members:

--- a/ispyb/__init__.py
+++ b/ispyb/__init__.py
@@ -6,7 +6,7 @@ except ImportError:
   import ConfigParser as configparser
 import logging
 
-__version__ = '4.10.0'
+__version__ = '4.11.0'
 
 _log = logging.getLogger('ispyb')
 

--- a/ispyb/model/__future__.py
+++ b/ispyb/model/__future__.py
@@ -1,0 +1,88 @@
+from __future__ import absolute_import, division, print_function
+
+# Enables direct database functions in places where stored procedures are not
+# yet available. To use, run:
+#
+# import ispyb.model.__future__
+# ispyb.model.__future__.enable('/path/to/.../database.cfg')
+
+try:
+  import configparser
+except ImportError:
+  import ConfigParser as configparser
+import mysql.connector
+
+def enable(configuration_file):
+  global _db, _db_cc
+  '''Enable access to features that are currently under development.'''
+
+  cfgparser = configparser.RawConfigParser()
+  if not cfgparser.read(configuration_file):
+    raise RuntimeError('Could not read from configuration file %s' % configuration_file)
+  cfgsection = dict(cfgparser.items('ispyb'))
+  host = cfgsection.get('host')
+  port = cfgsection.get('port', 3306)
+  database = cfgsection.get('database')
+  username = cfgsection.get('username')
+  password = cfgsection.get('password')
+
+  # Open a direct MySQL connection
+  _db = mysql.connector.connect(host=host, port=port, user=username, password=password, database=database)
+  _db_cc = dictionary_contextcursor_factory(_db.cursor)
+
+  import ispyb.model.gridinfo
+  ispyb.model.gridinfo.GridInfo.reload = _get_gridinfo
+
+class dictionary_contextcursor_factory(object):
+  '''This class creates dictionary context manager objects for mysql.connector
+     cursors. By using a context manager it is ensured that cursors are
+     closed immediately after use.
+     Context managers created via this factory return results as a dictionary
+     by default, and offer a .run() function, which is an alias to .execute
+     that accepts query parameters as function parameters rather than a list.
+  '''
+
+  def __init__(self, cursor_factory_function):
+    '''Set up the context manager factory.'''
+
+    class contextmanager(object):
+      '''The context manager object which is actually used in the
+            with .. as ..:
+         clause.'''
+
+      def __init__(cm, parameters):
+        '''Store any constructor parameters, given as dictionary, so that they
+           can be passed to the cursor factory later.'''
+        cm.cursorparams = { 'dictionary': True }
+        cm.cursorparams.update(parameters)
+
+      def __enter__(cm):
+        '''Enter context. Instantiate and return the actual cursor using the
+           given constructor, parameters, and an extra .run() function.'''
+        cm.cursor = cursor_factory_function(**cm.cursorparams)
+
+        def flat_execute(stmt, *parameters):
+          '''Pass all given function parameters as a list to the existing
+             .execute() function.'''
+          return cm.cursor.execute(stmt, parameters)
+        setattr(cm.cursor, 'run', flat_execute)
+        return cm.cursor
+
+      def __exit__(cm, *args):
+        '''Leave context. Close cursor. Destroy reference.'''
+        cm.cursor.close()
+        cm.cursor = None
+
+    self._contextmanager_factory = contextmanager
+
+  def __call__(self, **parameters):
+    '''Creates and returns a context manager object.'''
+    return self._contextmanager_factory(parameters)
+
+def _get_gridinfo(self):
+  with _db_cc() as cursor:
+    cursor.run("SELECT * "
+               "FROM GridInfo "
+               "WHERE dataCollectionGroupId = %s "
+               "LIMIT 1;", self._dcgid)
+    self._data = cursor.fetchone()

--- a/ispyb/model/__future__.py
+++ b/ispyb/model/__future__.py
@@ -28,14 +28,14 @@ def enable(configuration_file):
 
   # Open a direct MySQL connection
   _db = mysql.connector.connect(host=host, port=port, user=username, password=password, database=database)
-  _db_cc = dictionary_contextcursor_factory(_db.cursor)
+  _db_cc = DictionaryContextcursorFactory(_db.cursor)
 
   import ispyb.model.gridinfo
   ispyb.model.gridinfo.GridInfo.reload = _get_gridinfo
   import ispyb.model.processingprogram
   ispyb.model.processingprogram.ProcessingProgram.reload = _get_autoprocprogram
 
-class dictionary_contextcursor_factory(object):
+class DictionaryContextcursorFactory(object):
   '''This class creates dictionary context manager objects for mysql.connector
      cursors. By using a context manager it is ensured that cursors are
      closed immediately after use.
@@ -47,7 +47,7 @@ class dictionary_contextcursor_factory(object):
   def __init__(self, cursor_factory_function):
     '''Set up the context manager factory.'''
 
-    class contextmanager(object):
+    class ContextManager(object):
       '''The context manager object which is actually used in the
             with .. as ..:
          clause.'''
@@ -75,7 +75,7 @@ class dictionary_contextcursor_factory(object):
         cm.cursor.close()
         cm.cursor = None
 
-    self._contextmanager_factory = contextmanager
+    self._contextmanager_factory = ContextManager
 
   def __call__(self, **parameters):
     '''Creates and returns a context manager object.'''

--- a/ispyb/model/__future__.py
+++ b/ispyb/model/__future__.py
@@ -32,6 +32,8 @@ def enable(configuration_file):
 
   import ispyb.model.gridinfo
   ispyb.model.gridinfo.GridInfo.reload = _get_gridinfo
+  import ispyb.model.processingprogram
+  ispyb.model.processingprogram.ProcessingProgram.reload = _get_autoprocprogram
 
 class dictionary_contextcursor_factory(object):
   '''This class creates dictionary context manager objects for mysql.connector
@@ -85,4 +87,15 @@ def _get_gridinfo(self):
                "FROM GridInfo "
                "WHERE dataCollectionGroupId = %s "
                "LIMIT 1;", self._dcgid)
+    self._data = cursor.fetchone()
+
+def _get_autoprocprogram(self):
+  with _db_cc() as cursor:
+    cursor.run("SELECT processingCommandLine as commandLine, processingPrograms as programs, "
+               "processingStatus as status, processingMessage as message, processingEndTime as endTime, "
+               "processingStartTime as startTime, processingEnvironment as environment, "
+               "processingJobId as jobId, recordTimeStamp, autoProcProgramId "
+               "FROM AutoProcProgram "
+               "WHERE autoProcProgramId = %s "
+               "LIMIT 1;", self._appid)
     self._data = cursor.fetchone()

--- a/ispyb/model/datacollection.py
+++ b/ispyb/model/datacollection.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import ispyb.model
+import ispyb.model.gridinfo
 
 class DataCollection(ispyb.model.DBCache):
   '''An object representing a DataCollection database entry. The object
@@ -105,7 +106,7 @@ class DataCollectionGroup(ispyb.model.DBCache):
   def gridinfo(self):
     '''Returns a GridInfo object.'''
     if self._cache_gridinfo is None:
-      self._cache_gridinfo = GridInfo(self.dcgid, self._db)
+      self._cache_gridinfo = ispyb.model.gridinfo.GridInfo(self.dcgid, self._db)
     return self._cache_gridinfo
 
   def __repr__(self):

--- a/ispyb/model/gridinfo.py
+++ b/ispyb/model/gridinfo.py
@@ -28,7 +28,8 @@ class GridInfo(ispyb.model.DBCache):
 
   @property
   def dcgid(self):
-    '''Returns the DataCollectionGroupID.'''
+    '''Returns the Data Collection Group ID associated with this grid
+       information.'''
     return self._dcgid
 
   def __repr__(self):
@@ -47,3 +48,20 @@ class GridInfo(ispyb.model.DBCache):
     return ('\n'.join((
       'GridInfo #{0.dcgid}',
     ))).format(self)
+
+ispyb.model.add_properties(GridInfo, (
+    ('dx_mm', 'dx_mm', 'Grid element width in mm'),
+    ('dy_mm', 'dy_mm', 'Grid element height in mm'),
+    ('id', 'gridInfoId', 'A unique ID identifying this grid information record'),
+    ('orientation', 'orientation', 'The orientation of the grid, either "horizontal" or "vertical"'),
+    ('pixels_per_micron_x', 'pixelsPerMicronX', 'Number of pixels per micrometre (horizontal) when displaying the grid in GDA'),
+    ('pixels_per_micron_y', 'pixelsPerMicronY', 'Number of pixels per micrometre (vertical) when displaying the grid in GDA'),
+    ('timestamp', 'recordTimeStamp', 'Time and date of record creation'),
+    ('steps_x', 'steps_x', 'Width of the grid scan in number of grid elements'),
+    ('steps_y', 'steps_y', 'Height of the grid scan in number of grid elements'),
+    ('snaked', 'snaked', 'Whether the fast scan axis is inverted (1) or kept (0) for every slow axis acquisition'),
+    ('snapshot_offset_pixel_x', 'snapshot_offsetXPixel',
+         'Horizontal distance from the top left corner in GDA to the first grid element'),
+    ('snapshot_offset_pixel_y', 'snapshot_offsetYPixel',
+         'Vertical distance from the top left corner in GDA to the first grid element'),
+))

--- a/ispyb/model/gridinfo.py
+++ b/ispyb/model/gridinfo.py
@@ -43,7 +43,7 @@ class GridInfo(ispyb.model.DBCache):
   def __str__(self):
     '''Returns a pretty-printed object representation.'''
     if not self.cached:
-      return 'GridInfo #%d (not yet loaded from database)' % self._dcid
+      return 'GridInfo #%d (not yet loaded from database)' % self._dcgid
     return ('\n'.join((
       'GridInfo #{0.dcgid}',
     ))).format(self)

--- a/ispyb/model/interface.py
+++ b/ispyb/model/interface.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import ispyb.model.datacollection
+import ispyb.model.processingprogram
 import ispyb.model.processingjob
 
 class ObjectModelMixIn():
@@ -8,7 +9,7 @@ class ObjectModelMixIn():
 
   def get_data_collection(self, dcid):
     '''Return a DataCollection object representing the information
-       about the selected data collection'''
+       about the selected data collection.'''
     return ispyb.model.datacollection.DataCollection(
         dcid,
         self.mx_acquisition,
@@ -16,7 +17,7 @@ class ObjectModelMixIn():
 
   def get_data_collection_group(self, dcgid):
     '''Return a DataCollectionGroup object representing the information
-       about the selected data collection group'''
+       about the selected data collection group.'''
     return ispyb.model.datacollection.DataCollectionGroup(
         dcgid,
         self,
@@ -28,4 +29,12 @@ class ObjectModelMixIn():
     return ispyb.model.processingjob.ProcessingJob(
         jobid,
         self.mx_processing,
+    )
+
+  def get_processing_program(self, appid):
+    '''Return an ProcessingProgram object representing the information
+       about a processing program invocation.'''
+    return ispyb.model.processingprogram.ProcessingProgram(
+        appid,
+        self,
     )

--- a/ispyb/model/processingjob.py
+++ b/ispyb/model/processingjob.py
@@ -32,7 +32,7 @@ class ProcessingJob(ispyb.model.DBCache):
 
   @property
   def DCID(self):
-    '''Returns the data collection id.'''
+    '''Returns the main data collection id.'''
     dcid = self._data['dataCollectionId']
     if dcid is None:
       return None
@@ -57,6 +57,8 @@ class ProcessingJob(ispyb.model.DBCache):
 
   @property
   def sweeps(self):
+    '''Returns a list of ProcessingJobImageSweeps involved in this
+       processing job.'''
     if self._cache_sweeps is None:
       self._cache_sweeps = ProcessingJobImageSweeps(self._jobid, self._db)
     return self._cache_sweeps

--- a/ispyb/model/processingjob.py
+++ b/ispyb/model/processingjob.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import collections
 
 import ispyb.model
-import ispyb.model.autoprocprogram
+import ispyb.model.processingprogram
 
 class ProcessingJob(ispyb.model.DBCache):
   '''An object representing a ProcessingJob database entry. The object lazily
@@ -304,7 +304,7 @@ class ProcessingJobPrograms(ispyb.model.DBCache):
     '''Load/update information from the database.'''
     try:
       self._data = [
-          ispyb.model.autoprocprogram.AutoProcProgram(p['id'], self._db, preload=p)
+          ispyb.model.processingprogram.ProcessingProgram(p['id'], self._db, preload=p)
           for p in self._db.retrieve_programs_for_job_id(self._jobid)
       ]
     except ispyb.exception.ISPyBNoResultException:

--- a/ispyb/model/processingprogram.py
+++ b/ispyb/model/processingprogram.py
@@ -2,14 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 import ispyb.model
 
-class AutoProcProgram(ispyb.model.DBCache):
+class ProcessingProgram(ispyb.model.DBCache):
   '''An object representing an AutoProcProgram database entry. The object
      lazily accesses the underlying database when necessary and exposes record
      data as python attributes.
   '''
 
   def __init__(self, appid, db_area, preload=None):
-    '''Create an AutoProcProgram object for a defined APPID. Requires
+    '''Create an ProcessingProgram object for a defined APPID. Requires
        a database data area object exposing further data access methods.
 
        :param appid: AutoProcProgramID
@@ -31,11 +31,6 @@ class AutoProcProgram(ispyb.model.DBCache):
   def appid(self):
     '''Returns the AutoProcProgramID.'''
     return self._appid
-
-  @property
-  def jobid(self):
-    '''Returns the associated ProcessingJob ID (if any).'''
-    return self._data['jobId']
 
   @property
   def status_text(self):
@@ -63,7 +58,7 @@ class AutoProcProgram(ispyb.model.DBCache):
       return 'AutoProcProgram #%d (not yet loaded from database)' % self._appid
     return ('\n'.join((
       'AutoProcProgram #{0.appid}',
-      '  Name         : {0.program}',
+      '  Name         : {0.name}',
       '  Status       : {0.status_text}',
       '  Command      : {0.command}',
       '  Environment  : {0.environment}',
@@ -74,10 +69,11 @@ class AutoProcProgram(ispyb.model.DBCache):
       '  Last Message : {0.message}',
     ))).format(self)
 
-ispyb.model.add_properties(AutoProcProgram, (
-    ('program', 'programs'),
+ispyb.model.add_properties(ProcessingProgram, (
+    ('name', 'programs'),
     ('command', 'commandLine'),
     ('environment', 'environment'),
+    ('jobid', 'jobId', 'Returns the associated ProcessingJob ID (if any).'),
     ('time_defined', 'recordTimeStamp'),
     ('time_start', 'startTime'),
     ('time_end', 'endTime'),

--- a/tests/model/test_datacollection.py
+++ b/tests/model/test_datacollection.py
@@ -60,13 +60,15 @@ record = {
     k: getattr(mock.sentinel, k)
     for k in database_column_to_attribute_name
 }
+record["imgDir"] = "/path/to/some/images/"
+record["fileTemplate"] = "file_####.cbf"
 
 @pytest.mark.parametrize('column,attribute', filter(lambda ca: ca[1], database_column_to_attribute_name.items()))
 def test_datacollection_model_attributes_return_correct_values(column, attribute):
   dc = ispyb.model.datacollection.DataCollection(1234, None, preload=record)
   assert getattr(dc, attribute) == record[column]
 
-@pytest.mark.parametrize('printed_attribute', ('startTime', 'endTime'))
+@pytest.mark.parametrize('printed_attribute', ('startTime', 'endTime', 'imgDir', 'fileTemplate'))
 def test_pretty_printing_datacollection_shows_attribute(printed_attribute):
   dc_str = str(ispyb.model.datacollection.DataCollection(1234, None, preload=record))
   assert "1234" in dc_str


### PR DESCRIPTION
I've added a mechanism so we can use standard SQL commands alongside stored procedures for active development. The idea is that we can then use the object models in development even when the database functionality is not deployed yet ([MXSW-1173](https://jira.diamond.ac.uk/browse/MXSW-1173), [MXSW-1174](https://jira.diamond.ac.uk/browse/MXSW-1174)).

So, as an example without this patch:
```python
import ispyb
with ispyb.open(credentials) as i:
  print i.get_data_collection_group(2714865).gridinfo.orientation

NotImplementedError: TODO: Not implemented yet
```
and with this patch:
```python
import ispyb
with ispyb.open(credentials) as i:
  print i.get_data_collection_group(2714865).gridinfo.orientation

NotImplementedError: TODO: Not implemented yet

# Explicitly enable development functions
import ispyb.model.__future__                                                                                         
ispyb.model.__future__.enable(credentials_for_sql_access)

with ispyb.open(credentials) as i:
  print i.get_data_collection_group(2714865).gridinfo.orientation

horizontal
```

