### PR TITLE
Add upsert_program_ex function

### DIFF
--- a/ispyb/model/__future__.py
+++ b/ispyb/model/__future__.py
@@ -97,5 +97,5 @@ def _get_autoprocprogram(self):
                "processingJobId as jobId, recordTimeStamp, autoProcProgramId "
                "FROM AutoProcProgram "
                "WHERE autoProcProgramId = %s "
-               "LIMIT 1;", self._appid)
+               "LIMIT 1;", self._app_id)
     self._data = cursor.fetchone()

--- a/ispyb/model/processingprogram.py
+++ b/ispyb/model/processingprogram.py
@@ -8,29 +8,29 @@ class ProcessingProgram(ispyb.model.DBCache):
      data as python attributes.
   '''
 
-  def __init__(self, appid, db_area, preload=None):
+  def __init__(self, app_id, db_area, preload=None):
     '''Create an ProcessingProgram object for a defined APPID. Requires
        a database data area object exposing further data access methods.
 
-       :param appid: AutoProcProgramID
+       :param app_id: AutoProcProgramID
        :param db_area: ISPyB database data area object
        :return: An AutoProcProgram object representing the database entry for
                 the specified job AutoProcProgramID
     '''
     self._db = db_area
-    self._appid = int(appid)
+    self._app_id = int(app_id)
     if preload:
       self._data = preload
 
   def reload(self):
     '''Load/update information from the database.'''
     raise NotImplementedError("Don't know the API call for this")
-#   self._data = self._db.retrieve_job(self._appid)[0]
+#   self._data = self._db.retrieve_job(self._app_id)[0]
 
   @property
-  def appid(self):
+  def app_id(self):
     '''Returns the AutoProcProgramID.'''
-    return self._appid
+    return self._app_id
 
   @property
   def status_text(self):
@@ -47,7 +47,7 @@ class ProcessingProgram(ispyb.model.DBCache):
     '''Returns an object representation, including the AutoProcProgramID,
        the database connection interface object, and the cache status.'''
     return '<AutoProcProgram #%d (%s), %r>' % (
-        self._appid,
+        self._app_id,
         'cached' if self.cached else 'uncached',
         self._db
     )
@@ -55,17 +55,17 @@ class ProcessingProgram(ispyb.model.DBCache):
   def __str__(self):
     '''Returns a pretty-printed object representation.'''
     if not self.cached:
-      return 'AutoProcProgram #%d (not yet loaded from database)' % self._appid
+      return 'AutoProcProgram #%d (not yet loaded from database)' % self._app_id
     return ('\n'.join((
-      'AutoProcProgram #{0.appid}',
+      'AutoProcProgram #{0.app_id}',
       '  Name         : {0.name}',
       '  Status       : {0.status_text}',
       '  Command      : {0.command}',
       '  Environment  : {0.environment}',
-      '  ProcessingJob: {0.jobid}',
+      '  ProcessingJob: {0.job_id}',
       '  Defined      : {0.time_defined}',
       '  Started      : {0.time_start}',
-      '  Last Update  : {0.time_end}',
+      '  Last Update  : {0.time_update}',
       '  Last Message : {0.message}',
     ))).format(self)
 
@@ -73,10 +73,10 @@ ispyb.model.add_properties(ProcessingProgram, (
     ('name', 'programs'),
     ('command', 'commandLine'),
     ('environment', 'environment'),
-    ('jobid', 'jobId', 'Returns the associated ProcessingJob ID (if any).'),
+    ('job_id', 'jobId', 'Returns the associated ProcessingJob ID (if any).'),
     ('time_defined', 'recordTimeStamp'),
     ('time_start', 'startTime'),
-    ('time_end', 'endTime'),
+    ('time_update', 'endTime'),
     ('status', 'status'),
     ('message', 'message'),
 ))

--- a/ispyb/sp/mxprocessing.py
+++ b/ispyb/sp/mxprocessing.py
@@ -15,9 +15,6 @@ from ispyb.strictordereddict import StrictOrderedDict
 class MXProcessing(ispyb.interface.processing.IF):
   '''MXProcessing provides methods to store MX processing data.'''
 
-  def __init__(self):
-    pass
-
   _program_params = StrictOrderedDict([('id',None), ('cmd_line',None), ('programs',None),
     ('status',None), ('message',None), ('starttime',None), ('updatetime',None), ('environment',None), ('processing_job_id',None),
     ('recordtime',None)])
@@ -125,6 +122,26 @@ class MXProcessing(ispyb.interface.processing.IF):
   def upsert_program(self, values):
     '''Store new or update existing program params.'''
     return self.get_connection().call_sp_write(procname='upsert_processing_program', args=values) # doesn't work with dict cursors
+
+  def upsert_program_ex(self, program_id=None, processing_id=None,
+      command_line=None, program_name=None, environment=None,
+      record_timestamp=None, status=None, start_time=None,
+      update_time=None, update_message=None):
+    '''Store new or update existing processing program information.
+
+       :param status: An integer describing the processing status. 1 means
+                      success, 0 means failure. If left at None then the
+                      status is left undefined or unchanged. The underlying
+                      stored procedure does not allow any more changes to the
+                      record once the status is set.
+       :return: The program_id.
+    '''
+    return self.get_connection().call_sp_write(
+        procname='upsert_processing_program',
+        args=[ program_id, command_line, program_name, status, update_message,
+               start_time, update_time, environment, processing_id,
+               record_timestamp ],
+    )
 
   def upsert_program_attachment(self, values):
     '''Store new or update existing program attachment params.'''

--- a/ispyb/sp/mxprocessing.py
+++ b/ispyb/sp/mxprocessing.py
@@ -123,10 +123,9 @@ class MXProcessing(ispyb.interface.processing.IF):
     '''Store new or update existing program params.'''
     return self.get_connection().call_sp_write(procname='upsert_processing_program', args=values) # doesn't work with dict cursors
 
-  def upsert_program_ex(self, program_id=None, processing_id=None,
-      command_line=None, program_name=None, environment=None,
-      record_timestamp=None, status=None, start_time=None,
-      update_time=None, update_message=None):
+  def upsert_program_ex(self, program_id=None, job_id=None, name=None,
+      command=None, environment=None, message=None, status=None,
+      time_defined=None, time_start=None, time_update=None):
     '''Store new or update existing processing program information.
 
        :param status: An integer describing the processing status. 1 means
@@ -138,9 +137,9 @@ class MXProcessing(ispyb.interface.processing.IF):
     '''
     return self.get_connection().call_sp_write(
         procname='upsert_processing_program',
-        args=[ program_id, command_line, program_name, status, update_message,
-               start_time, update_time, environment, processing_id,
-               record_timestamp ],
+        args=[ program_id, command, name, status, message,
+               time_start, time_update, environment, job_id,
+               time_defined ],
     )
 
   def upsert_program_attachment(self, values):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,12 @@ def testconfig():
   return config_file
 
 @pytest.fixture
+def testdb():
+  '''Return an ISPyB connection object for the test database configuration.'''
+  with ispyb.open(testconfig()) as conn:
+    yield conn
+
+@pytest.fixture
 def testconfig_ws():
   '''Return the path to a configuration file pointing to a websocket
      test instance.'''


### PR DESCRIPTION
This does the same things as upsert_program, but defines all arguments
as function parameters, which means they can be found easily, can be
documented properly, can be given in any order and do no longer need to
be pre-declared. In interactive Python shells (iPython etc) this also enables tab completion.

Added the function in addition to the existing function with an '_ex'
suffix. Suggest renaming it to the without-'_ex' name with the next
major release (5.0).