### PR TITLE
Enable autocommit for model.__future__ connections

### DIFF
--- a/ispyb/__init__.py
+++ b/ispyb/__init__.py
@@ -6,7 +6,7 @@ except ImportError:
   import ConfigParser as configparser
 import logging
 
-__version__ = '4.11.0'
+__version__ = '4.11.1'
 
 _log = logging.getLogger('ispyb')
 

--- a/ispyb/model/__future__.py
+++ b/ispyb/model/__future__.py
@@ -46,6 +46,7 @@ def enable(configuration_file):
 
   # Open a direct MySQL connection
   _db = mysql.connector.connect(host=host, port=port, user=username, password=password, database=database)
+  _db.autocommit = True
   _db_cc = DictionaryContextcursorFactory(_db.cursor)
   _db_config = configuration_file
 


### PR DESCRIPTION
Otherwise all __future__ requests could be running on a database view
from the time of the first request.

Is it OK to make this a 4.11.1 bugfix release? (would also include 9a53e7572743e51d9e466be359d5f56e1ccfb437 and 4ec84fcd65798e1422cfb59837b8149ff6f18b79)