### PR TITLE
Protect against database connection loss

### DIFF
--- a/conf/config.example.cfg
+++ b/conf/config.example.cfg
@@ -5,4 +5,3 @@ pw =
 host = localhost
 port = 3306
 db = ispybtest
-conn_inactivity = 360

--- a/ispyb/__init__.py
+++ b/ispyb/__init__.py
@@ -6,7 +6,7 @@ except ImportError:
   import ConfigParser as configparser
 import logging
 
-__version__ = '4.11.1'
+__version__ = '4.12.0'
 
 _log = logging.getLogger('ispyb')
 

--- a/ispyb/model/__future__.py
+++ b/ispyb/model/__future__.py
@@ -15,7 +15,7 @@ import mysql.connector
 
 _db_config = None
 
-def enable(configuration_file):
+def enable(configuration_file, section='ispyb'):
   '''Enable access to features that are currently under development.'''
 
   global _db, _db_cc, _db_config
@@ -37,12 +37,12 @@ def enable(configuration_file):
   cfgparser = configparser.RawConfigParser()
   if not cfgparser.read(configuration_file):
     raise RuntimeError('Could not read from configuration file %s' % configuration_file)
-  cfgsection = dict(cfgparser.items('ispyb'))
+  cfgsection = dict(cfgparser.items(section))
   host = cfgsection.get('host')
   port = cfgsection.get('port', 3306)
-  database = cfgsection.get('database')
-  username = cfgsection.get('username')
-  password = cfgsection.get('password')
+  database = cfgsection.get('database', cfgsection.get('db'))
+  username = cfgsection.get('username', cfgsection.get('user'))
+  password = cfgsection.get('password', cfgsection.get('pw'))
 
   # Open a direct MySQL connection
   _db = mysql.connector.connect(host=host, port=port, user=username, password=password, database=database)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+import ispyb
 import pytest
 
 @pytest.fixture


### PR DESCRIPTION
If required, trigger a database reconnect with [```.ping```](https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlconnection-ping.html) before creating a new
database cursor.

This replaces the previous time-based reconnection method and fixes #3.
The connection inactivity parameter was retained in the constructor
although it no longer has any effect.