### PR TITLE
New Reconn params

### DIFF
--- a/conf/config.example.cfg
+++ b/conf/config.example.cfg
@@ -5,3 +5,5 @@ pw =
 host = localhost
 port = 3306
 db = ispybtest
+reconn_attempts = 6
+reconn_delay = 1

--- a/conf/config.example.cfg
+++ b/conf/config.example.cfg
@@ -1,5 +1,5 @@
 # Copy this to config.cfg and modify it for your environment
-[ispyb_mysql_sp]
+[ispyb_mariadb_sp]
 user = root
 pw =
 host = localhost

--- a/ispyb/__init__.py
+++ b/ispyb/__init__.py
@@ -6,7 +6,7 @@ except ImportError:
   import ConfigParser as configparser
 import logging
 
-__version__ = '4.13.1'
+__version__ = '4.14.0'
 
 _log = logging.getLogger('ispyb')
 
@@ -23,18 +23,17 @@ def open(configuration_file):
     raise AttributeError('No configuration found at %s' % configuration_file)
 
   conn = None
-  if config.has_section('ispyb_mysql_sp'):
+  if config.has_section('ispyb_mariadb_sp'):
     from ispyb.connector.mysqlsp.main import ISPyBMySQLSPConnector as Connector
-    credentials = dict(config.items('ispyb_mysql_sp'))
-    _log.debug('Creating MySQL Stored Procedure connection from %s', configuration_file)
+    credentials = dict(config.items('ispyb_mariadb_sp'))
+    _log.debug('Creating MariaDB Stored Procedure connection from %s', configuration_file)
     conn = Connector(**credentials)
-
   elif config.has_section('ispyb_ws'):
     from ispyb.connector.ws.main import ISPyBWSConnector as Connector
     credentials = dict(config.items('ispyb_ws'))
     _log.debug('Creating Webservices connection from %s', configuration_file)
     conn = Connector(**credentials)
   else:
-    raise AttributeError('No supported connection type found in %s' % configuration_file)
+    raise AttributeError('No supported connection type found in %s. For an example of a valid config file, please see config.example.cfg.' % configuration_file)
 
   return conn

--- a/ispyb/__init__.py
+++ b/ispyb/__init__.py
@@ -6,7 +6,7 @@ except ImportError:
   import ConfigParser as configparser
 import logging
 
-__version__ = '4.14.0'
+__version__ = '4.13.1'
 
 _log = logging.getLogger('ispyb')
 

--- a/ispyb/connector/mysqlsp/main.py
+++ b/ispyb/connector/mysqlsp/main.py
@@ -15,7 +15,7 @@ class ISPyBMySQLSPConnector(ispyb.interface.connection.IF):
   '''Provides a connector to an ISPyB MySQL/MariaDB database through stored procedures.
   '''
 
-  def __init__(self, user=None, pw=None, host='localhost', db=None, port=3306, conn_inactivity=360, reconn_attempts=6, reconn_delay=1):
+  def __init__(self, user=None, pw=None, host='localhost', db=None, port=3306, reconn_attempts=6, reconn_delay=1):
     self.lock = threading.Lock()
     self.connect(user=user, pw=pw, host=host, db=db, port=port)
 
@@ -28,7 +28,7 @@ class ISPyBMySQLSPConnector(ispyb.interface.connection.IF):
   def __exit__(self, type, value, traceback):
     self.disconnect()
 
-  def connect(self, user=None, pw=None, host='localhost', db=None, port=3306, conn_inactivity=360, reconn_attempts=6, reconn_delay=1):
+  def connect(self, user=None, pw=None, host='localhost', db=None, port=3306, reconn_attempts=6, reconn_delay=1):
     self.disconnect()
 
     self.conn = mysql.connector.connect(user=user,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -47,7 +47,7 @@ def test_retrieve_failure(testconfig):
       rs = conn.mx_acquisition.retrieve_data_collection_main(0)
 
 def test_database_reconnects_on_connection_failure(testconfig, testdb):
-  ispyb.model.__future__.enable(testconfig, section='ispyb_mysql_sp')
+  ispyb.model.__future__.enable(testconfig, section='ispyb_mariadb_sp')
 
   # Create minimal data collection and data collection group for test
   params = testdb.mx_acquisition.get_data_collection_group_params()


### PR DESCRIPTION
* New reconn params in config.example.cfg
* Change config section name to `ispyb_mariadb_sp` mostly just so we can have two sections while transitioning, as we may have some old clients still pointed at the same config file, and these would break if they encountered the new reconn params. 
* Since we now have a new config section name, remove the old conn_inactivity param from example config and code
* Bump up version

I can't think of a way to design a test case for these beyond the re-connection test we have already. Hence no test case.