### PR TITLE
Move ispyb.exceptions to ispyb

### DIFF
--- a/ispyb/__init__.py
+++ b/ispyb/__init__.py
@@ -38,3 +38,18 @@ def open(configuration_file):
     raise AttributeError('No supported connection type found in %s' % configuration_file)
 
   return conn
+
+
+class ISPyBException(Exception):
+  '''Base class for all exceptions'''
+
+class ConnectionError(ISPyBException):
+  '''Unable to connect or connection has been closed.'''
+
+class NoResult(ISPyBException):
+  '''Query returned no result.'''
+
+class ReadWriteError(ISPyBException):
+  '''Record could not be read, inserted, updated or deleted. This could be due to
+  illegal values, the wrong number of parameters, a violation of table or
+  index constraints, or a database failure.'''

--- a/ispyb/exception.py
+++ b/ispyb/exception.py
@@ -1,20 +1,14 @@
-class ISPyBException(Exception):
-  '''Base class for all exceptions'''
+from __future__ import absolute_import, division, print_function
 
-class ISPyBConnectionException(ISPyBException):
-  '''Unable to connect or connection has been closed.'''
+import warnings
 
-class ISPyBNoResultException(ISPyBException):
-  '''Query returned no result.'''
+import ispyb
 
-class ISPyBWriteFailed(ISPyBException):
-  '''Record could not be inserted, updated or deleted. This could be due to
-  illegal values, the wrong number of parameters, a violation of table or
-  index constraints, or a database failure.'''
+warnings.warn("ispyb.exceptions is deprecated and will be removed in the next release. Use the exceptions underneath ispyb. instead.", DeprecationWarning)
 
-class ISPyBRetrieveFailed(ISPyBException):
-  '''Record(s) could not be retrieved. This could be due to invalid argument
-  values, or a database failure. '''
-
-class ISPyBKeyProblem(ISPyBException):
-  '''A mandatory key is missing or its value is None.'''
+ISPyBException = ispyb.ISPyBException
+ISPyBConnectionException = ispyb.ConnectionError
+ISPyBNoResultException = ispyb.NoResult
+ISPyBWriteFailed = ispyb.ReadWriteError
+ISPyBRetrieveFailed = ispyb.ReadWriteError
+ISPyBKeyProblem = KeyError

--- a/ispyb/model/gridinfo.py
+++ b/ispyb/model/gridinfo.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-import ispyb.exception
+import ispyb
 import ispyb.model
 
 class GridInfo(ispyb.model.DBCache):
@@ -27,7 +27,7 @@ class GridInfo(ispyb.model.DBCache):
     '''Load/update information from the database.'''
     try:
       self._data = self._db.mx_acquisition.retrieve_dcg_grid(self._dcgid)[0]
-    except ispyb.exception.ISPyBNoResultException:
+    except ispyb.NoResult:
       self._data = None
 
   @property

--- a/ispyb/model/processingjob.py
+++ b/ispyb/model/processingjob.py
@@ -164,7 +164,7 @@ class ProcessingJobParameters(ispyb.model.DBCache):
                p['parameterKey'], p['parameterValue'], p['parameterId']))
           for p in self._db.retrieve_job_parameters(self._jobid)
       ]
-    except ispyb.exception.ISPyBNoResultException:
+    except ispyb.NoResult:
       self._data = []
     self._data_dict = collections.OrderedDict(self._data)
 
@@ -261,7 +261,7 @@ class ProcessingJobImageSweeps(ispyb.model.DBCache):
           ProcessingJobImageSweep(p['dataCollectionId'], p['startImage'], p['endImage'], p['sweepId'], self._db)
           for p in self._db.retrieve_job_image_sweeps(self._jobid)
       ]
-    except ispyb.exception.ISPyBNoResultException:
+    except ispyb.NoResult:
       self._data = []
 
   def __getitem__(self, item):
@@ -307,7 +307,7 @@ class ProcessingJobPrograms(ispyb.model.DBCache):
           ispyb.model.processingprogram.ProcessingProgram(p['id'], self._db, preload=p)
           for p in self._db.retrieve_programs_for_job_id(self._jobid)
       ]
-    except ispyb.exception.ISPyBNoResultException:
+    except ispyb.NoResult:
       self._data = []
 
   def __getitem__(self, item):

--- a/ispyb/xmltools.py
+++ b/ispyb/xmltools.py
@@ -1,9 +1,9 @@
+from __future__ import absolute_import, division, print_function
+
 # XML-to-dict code from here:
 # http://code.activestate.com/recipes/410469-xml-as-dictionary/
 
 from xml.etree import ElementTree
-
-from ispyb.exception import ISPyBKeyProblem
 
 class XmlListConfig(list):
     def __init__(self, aList):
@@ -100,11 +100,11 @@ def mx_data_reduction_to_ispyb(xmldict, dc_id = None, mxprocessing = None):
     scaling = xmldict['AutoProcScalingContainer']['AutoProcScaling']
 
     if proc == None:
-        raise ISPyBKeyProblem("Missing key 'AutoProc'")
+        raise KeyError("Missing key 'AutoProc'")
     if scaling == None:
-        raise ISPyBKeyProblem("Missing key 'AutoProcScaling'")
+        raise KeyError("Missing key 'AutoProcScaling'")
     if int_containers == None:
-        raise ISPyBKeyProblem("Missing key 'AutoProcIntegrationContainer'")
+        raise KeyError("Missing key 'AutoProcIntegrationContainer'")
 
     s = [None, None, None]
     for i in range(0,3):
@@ -117,7 +117,7 @@ def mx_data_reduction_to_ispyb(xmldict, dc_id = None, mxprocessing = None):
             s[2] = stats
 
     if s[0] == None or s[1] == None or s[2] == None:
-        raise ISPyBKeyProblem("Need 3 'AutoProcScalingStatistics' keys in 'AutoProcScalingContainer'")
+        raise KeyError("Need 3 'AutoProcScalingStatistics' keys in 'AutoProcScalingContainer'")
 
     for int_container in int_containers:
         integration = int_container['AutoProcIntegration']
@@ -125,7 +125,7 @@ def mx_data_reduction_to_ispyb(xmldict, dc_id = None, mxprocessing = None):
             if dc_id is not None:
     	        integration['dataCollectionId'] = dc_id
             else:
-                raise ISPyBKeyProblem("Missing key 'dataCollectionId'")
+                raise KeyError("Missing key 'dataCollectionId'")
 
     # Store results from MX data reduction pipelines
     # ...first the program info

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import threading
 
-import ispyb.exception
+import ispyb
 import ispyb.model.__future__
 import mysql.connector.errors
 import pytest
@@ -39,7 +39,7 @@ def test_multi_threads_upsert(testdb):
             worker.join()
 
 def test_retrieve_failure(testdb):
-    with pytest.raises(ispyb.exception.ISPyBNoResultException):
+    with pytest.raises(ispyb.NoResult):
       rs = testdb.mx_acquisition.retrieve_data_collection_main(0)
 
 def test_database_reconnects_on_connection_failure(testconfig, testdb):

--- a/tests/test_mxacquisition.py
+++ b/tests/test_mxacquisition.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from datetime import datetime
 
-import ispyb.exception
+import ispyb
 import pytest
 
 def test_mxacquisition_methods(testdb):
@@ -54,7 +54,7 @@ def test_mxacquisition_methods(testdb):
         params['comments'] = 'Forgot to comment!'
         iid = mxacquisition.upsert_image(list(params.values()))
 
-        with pytest.raises(ispyb.exception.ISPyBNoResultException):
+        with pytest.raises(ispyb.NoResult):
           gridinfo = mxacquisition.retrieve_dcg_grid(dcgid)
 
         params = mxacquisition.get_dcg_grid_params()


### PR DESCRIPTION
and remove 'ISPyB' and 'Exception' from class names.

Currently we use the exceptions as in:
```python
    try:
        (..)
    except ispyb.exception.ISPyBNoResultException:
        (..)
```
which is overly verbose:
* It contains the word 'ispyb' twice
* It contains the word 'exception' twice,
* which is completely pointless because anything in
  ```except (..):``` and ```raise (..)``` must be an exception anyway.

(and yes, I am aware I was the one who came up with this in the first place 😄 )

Therefore move all exceptions from ```ispyb.exceptions``` into the ispyb main
class, giving them shorter names. ```ISPyBKeyProblem``` is replaced by the
python builtin ```KeyError```. ```ispyb.exception``` remains available to import
until the next major release but will generate a deprecation warning on
import.