### PR TITLE
Authorisation for relevant methods

### DIFF
--- a/conf/lookups.sql
+++ b/conf/lookups.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.17  Distrib 10.3.11-MariaDB, for Linux (x86_64)
+-- MySQL dump 10.17  Distrib 10.3.13-MariaDB, for Linux (x86_64)
 --
 -- Host: localhost    Database: ispyb_build
 -- ------------------------------------------------------
--- Server version	10.3.11-MariaDB
+-- Server version	10.3.13-MariaDB
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -30,7 +30,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `SchemaStatus` WRITE;
 /*!40000 ALTER TABLE `SchemaStatus` DISABLE KEYS */;
-INSERT INTO `SchemaStatus` (`schemaStatusId`, `scriptName`, `schemaStatus`, `recordTimeStamp`) VALUES (6,'20180213_BLSample_subLocation.sql','DONE','2018-02-13 13:27:19'),(12,'20180213_DataCollectionFileAttachment_fileType.sql','DONE','2018-02-13 15:12:54'),(16,'20180303_v_run_to_table.sql','DONE','2018-07-25 15:11:18'),(19,'20180328_ImageQualityIndicators_alter_table.sql','DONE','2018-07-25 15:11:18'),(22,'20180410_BeamLineSetup_alter.sql','DONE','2018-07-25 15:11:18'),(25,'20180413_BeamLineSetup_and_Detector_alter.sql','DONE','2018-07-25 15:11:18'),(28,'20180501_DataCollectionGroup_experimentType_enum.sql','DONE','2018-07-25 15:11:18'),(31,'20180531_ScreeningOutput_alignmentSuccess.sql','DONE','2018-07-25 15:11:18'),(34,'20180629_DataCollection_imageContainerSubPath.sql','DONE','2018-07-25 15:11:18'),(35,'20180913_BeamCalendar.sql','DONE','2018-09-19 09:52:45'),(36,'2018_09_19_DataCollection_imageDirectory_comment.sql','DONE','2018-09-19 12:38:01'),(37,'2018_09_27_increase_schema_version.sql','DONE','2018-09-27 13:17:15'),(38,'2018_11_01_XrayCenteringResult.sql','DONE','2018-11-01 13:36:53'),(39,'2018_11_01_AutoProcProgram_dataCollectionId.sql','DONE','2018-11-01 15:10:38'),(40,'2018_11_01_AutoProcProgramMessage.sql','DONE','2018-11-01 15:28:17'),(44,'2018_11_01_DiffractionPlan_centeringMethod.sql','DONE','2018-11-01 22:51:36'),(45,'2018_11_02_DataCollectionGroup_experimentType_enum.sql','DONE','2018-11-02 11:54:15'),(47,'2018_11_05_spelling_of_centring.sql','DONE','2018-11-05 15:31:38'),(48,'2018_11_09_AutoProcProgram_update_processing_program.sql','DONE','2018-11-09 16:38:34'),(49,'2018_11_14_AutoProcProgramMessage_autoinc.sql','DONE','2018-11-14 10:15:27'),(50,'2018_11_22_AutoProcProgram_processingStatus_update.sql','DONE','2018-11-22 16:11:15');
+INSERT INTO `SchemaStatus` (`schemaStatusId`, `scriptName`, `schemaStatus`, `recordTimeStamp`) VALUES (6,'20180213_BLSample_subLocation.sql','DONE','2018-02-13 13:27:19'),(12,'20180213_DataCollectionFileAttachment_fileType.sql','DONE','2018-02-13 15:12:54'),(16,'20180303_v_run_to_table.sql','DONE','2018-07-25 15:11:18'),(19,'20180328_ImageQualityIndicators_alter_table.sql','DONE','2018-07-25 15:11:18'),(22,'20180410_BeamLineSetup_alter.sql','DONE','2018-07-25 15:11:18'),(25,'20180413_BeamLineSetup_and_Detector_alter.sql','DONE','2018-07-25 15:11:18'),(28,'20180501_DataCollectionGroup_experimentType_enum.sql','DONE','2018-07-25 15:11:18'),(31,'20180531_ScreeningOutput_alignmentSuccess.sql','DONE','2018-07-25 15:11:18'),(34,'20180629_DataCollection_imageContainerSubPath.sql','DONE','2018-07-25 15:11:18'),(35,'20180913_BeamCalendar.sql','DONE','2018-09-19 09:52:45'),(36,'2018_09_19_DataCollection_imageDirectory_comment.sql','DONE','2018-09-19 12:38:01'),(37,'2018_09_27_increase_schema_version.sql','DONE','2018-09-27 13:17:15'),(38,'2018_11_01_XrayCenteringResult.sql','DONE','2018-11-01 13:36:53'),(39,'2018_11_01_AutoProcProgram_dataCollectionId.sql','DONE','2018-11-01 15:10:38'),(40,'2018_11_01_AutoProcProgramMessage.sql','DONE','2018-11-01 15:28:17'),(44,'2018_11_01_DiffractionPlan_centeringMethod.sql','DONE','2018-11-01 22:51:36'),(45,'2018_11_02_DataCollectionGroup_experimentType_enum.sql','DONE','2018-11-02 11:54:15'),(47,'2018_11_05_spelling_of_centring.sql','DONE','2018-11-05 15:31:38'),(48,'2018_11_09_AutoProcProgram_update_processing_program.sql','DONE','2018-11-09 16:38:34'),(49,'2018_11_14_AutoProcProgramMessage_autoinc.sql','DONE','2018-11-14 10:15:27'),(50,'2018_11_22_AutoProcProgram_processingStatus_update.sql','DONE','2018-11-22 16:11:15'),(51,'2018_12_04_EnergyScan_and_XFEFluorescenceSpectrum_add_axisPosition.sql','DONE','2018-12-04 14:13:23'),(52,'2018_12_20_DataCollectionGroup_scanParameters.sql','DONE','2018-12-20 17:30:04'),(53,'2019_01_14_Proposal_state.sql','DONE','2019-01-14 12:13:31'),(54,'2019_01_14_ProcessingJobParameter_parameterValue.sql','DONE','2019-01-14 14:00:02'),(57,'2019_01_15_Detector_localName.sql','DONE','2019-01-15 23:01:15'),(58,'2019_02_04_BLSession_unique_index.sql','DONE','2019-02-04 13:52:19');
 /*!40000 ALTER TABLE `SchemaStatus` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -127,7 +127,7 @@ UNLOCK TABLES;
 
 LOCK TABLES `Detector` WRITE;
 /*!40000 ALTER TABLE `Detector` DISABLE KEYS */;
-INSERT INTO `Detector` (`detectorId`, `detectorType`, `detectorManufacturer`, `detectorModel`, `detectorPixelSizeHorizontal`, `detectorPixelSizeVertical`, `DETECTORMAXRESOLUTION`, `DETECTORMINRESOLUTION`, `detectorSerialNumber`, `detectorDistanceMin`, `detectorDistanceMax`, `trustedPixelValueRangeLower`, `trustedPixelValueRangeUpper`, `sensorThickness`, `overload`, `XGeoCorr`, `YGeoCorr`, `detectorMode`, `density`, `composition`, `numberOfPixelsX`, `numberOfPixelsY`, `detectorRollMin`, `detectorRollMax`) VALUES (4,'Photon counting','In-house','Excalibur',NULL,NULL,NULL,NULL,'1109-434',100,300,NULL,NULL,NULL,NULL,NULL,NULL,NULL,55,'CrO3Br5Sr10',NULL,NULL,NULL,NULL),(8,'Diamond XPDF detector',NULL,NULL,NULL,NULL,NULL,NULL,'1109-761',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,10.4,'C+Br+He',NULL,NULL,NULL,NULL);
+INSERT INTO `Detector` (`detectorId`, `detectorType`, `detectorManufacturer`, `detectorModel`, `detectorPixelSizeHorizontal`, `detectorPixelSizeVertical`, `DETECTORMAXRESOLUTION`, `DETECTORMINRESOLUTION`, `detectorSerialNumber`, `detectorDistanceMin`, `detectorDistanceMax`, `trustedPixelValueRangeLower`, `trustedPixelValueRangeUpper`, `sensorThickness`, `overload`, `XGeoCorr`, `YGeoCorr`, `detectorMode`, `density`, `composition`, `numberOfPixelsX`, `numberOfPixelsY`, `detectorRollMin`, `detectorRollMax`, `localName`) VALUES (4,'Photon counting','In-house','Excalibur',NULL,NULL,NULL,NULL,'1109-434',100,300,NULL,NULL,NULL,NULL,NULL,NULL,NULL,55,'CrO3Br5Sr10',NULL,NULL,NULL,NULL,NULL),(8,'Diamond XPDF detector',NULL,NULL,NULL,NULL,NULL,NULL,'1109-761',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,10.4,'C+Br+He',NULL,NULL,NULL,NULL,NULL);
 /*!40000 ALTER TABLE `Detector` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -185,4 +185,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2018-11-23  9:18:11
+-- Dump completed on 2019-03-26 18:01:11

--- a/ispyb/sp/acquisition.py
+++ b/ispyb/sp/acquisition.py
@@ -70,9 +70,9 @@ class Acquisition(ispyb.interface.acquisition.IF):
     '''Insert or update a data collection file attachment.'''
     return self.get_connection().call_sp_write('upsert_dc_file_attachment', values)
 
-  def retrieve_data_collection_main(self, id):
+  def retrieve_data_collection_main(self, id, auth_login=None):
     '''Retrieve main data collection parameters for row with given id'''
-    return self.get_connection().call_sp_retrieve(procname='retrieve_dc_main', args=(id,))
+    return self.get_connection().call_sp_retrieve(procname='retrieve_dc_main_v2', args=(id, auth_login))
 
   def upsert_robot_action(self, values):
     '''Insert or update a robot action event.'''

--- a/ispyb/sp/core.py
+++ b/ispyb/sp/core.py
@@ -46,7 +46,7 @@ class Core(ispyb.interface.core.IF):
     StrictOrderedDict([('session_id',None), ('person_id',None), ('role',None), ('remote',None)])
 
   _sample_params =\
-    StrictOrderedDict([('id',None), ('crystalid',None), ('containerid',None), ('name',None), ('code',None),
+    StrictOrderedDict([('id',None), ('authLogin',None), ('crystalid',None), ('containerid',None), ('name',None), ('code',None),
                          ('location',None), ('holder_length',None), ('loop_length',None), ('loop_type',None),
                          ('wire_width',None), ('comments',None), ('status',None), ('is_in_sc',None)])
 
@@ -96,7 +96,7 @@ class Core(ispyb.interface.core.IF):
 
   def upsert_sample(self, values):
     '''Insert or update sample.'''
-    return self.get_connection().call_sf_write(funcname='upsert_sample', args=values)
+    return self.get_connection().call_sp_write(procname='upsert_sample', args=values)
 
   def retrieve_visit_id(self, visit):
     '''Get the database ID for a visit on the form mx1234-5.'''
@@ -138,6 +138,6 @@ class Core(ispyb.interface.core.IF):
     '''Get a result-set with the submitted plates not yet in local storage on a given beamline'''
     return self.get_connection().call_sp_retrieve(procname='retrieve_containers_submitted_non_ls', args=(beamline,))
 
-  def retrieve_proposal_title(self, proposal_code, proposal_number):
+  def retrieve_proposal_title(self, proposal_code, proposal_number, auth_login=None):
     '''Get the title of a given proposal'''
-    return self.get_connection().call_sf_retrieve(funcname='retrieve_proposal_title', args=(proposal_code, proposal_number))
+    return self.get_connection().call_sp_retrieve(procname='retrieve_proposal_title', args=(proposal_code, proposal_number, auth_login))

--- a/ispyb/sp/mxacquisition.py
+++ b/ispyb/sp/mxacquisition.py
@@ -94,13 +94,13 @@ class MXAcquisition(Acquisition):
     '''Insert or update the grid info associated with a data collection group'''
     return self.get_connection().call_sp_write('upsert_dcg_grid', values)
 
-  def retrieve_dcg_grid(self, dcgid):
+  def retrieve_dcg_grid(self, dcgid, auth_login=None):
     '''Retrieve a list of dictionaries containing the grid information for
        one data collection group id. Raises ISPyBNoResultException if there
        is no grid information available for the given DCGID.
        Generally the list will only contain a single dictionary.
     '''
-    return self.get_connection().call_sp_retrieve(procname='retrieve_grid_info_for_dcg', args=(dcgid,))
+    return self.get_connection().call_sp_retrieve(procname='retrieve_grid_info_for_dcg_v2', args=(dcgid, auth_login))
 
   @classmethod
   def get_energy_scan_params(cls):

--- a/ispyb/sp/mxprocessing.py
+++ b/ispyb/sp/mxprocessing.py
@@ -170,29 +170,35 @@ class MXProcessing(ispyb.interface.processing.IF):
     '''Update or insert new entry with info about views (image paths) for an MX molecular replacement run, e.g. Dimple.'''
     return self.get_connection().call_sp_write(procname='upsert_mrrun_blob', args=values)
 
-  def retrieve_job(self, id):
+  def retrieve_job(self, id, auth_login=None):
     '''Retrieve info about the processing job with id=id'''
-    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_job', args=(id,))
+    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_job_v2', args=(id, auth_login))
 
-  def retrieve_job_parameters(self, id):
+  def retrieve_job_parameters(self, id, auth_login=None):
     '''Retrieve info about the parameters for processing job with id=id'''
-    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_job_parameters', args=(id,))
+    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_job_parameters_v2', args=(id, auth_login))
 
-  def retrieve_job_image_sweeps(self, id):
+  def retrieve_job_image_sweeps(self, id, auth_login=None):
     '''Retrieve info about the image sweeps for job with id=id'''
-    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_job_image_sweeps', args=(id,))
+    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_job_image_sweeps_v2', args=(id, auth_login))
 
-  def retrieve_programs_for_job_id(self, id):
+  def retrieve_programs_for_job_id(self, id, auth_login=None):
     '''Retrieve the processing instances associated with the given processing job ID'''
-    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_programs_for_job_id', args=(id,))
+    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_programs_for_job_id_v2', args=(id, auth_login))
 
-  def retrieve_program_attachments_for_data_collection_group_and_program(self, id, program):
+  def retrieve_program_attachments_for_data_collection_group_and_program(self, id, program, auth_login=None):
     '''Retrieve the processing program attachments associated with the given data collection group and processing program'''
-    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_program_attachments_for_dc_group_and_program', args=(id,program))
+    return self.get_connection().call_sp_retrieve(
+      procname='retrieve_processing_program_attachments_for_dc_group_program_v2', 
+      args=(id, program, auth_login)
+    )
 
-  def retrieve_program_attachments_for_program_id(self, id):
+  def retrieve_program_attachments_for_program_id(self, id, auth_login=None):
     '''Retrieve the processing program attachments associated with the given processing program ID'''
-    return self.get_connection().call_sp_retrieve(procname='retrieve_processing_program_attachments_for_program_id', args=(id,))
+    return self.get_connection().call_sp_retrieve(
+      procname='retrieve_processing_program_attachments_for_program_id_v2', 
+      args=(id, auth_login)
+    )
 
   def upsert_job(self, values):
     '''Update or insert a new processing job entry'''

--- a/ispyb/sp/shipping.py
+++ b/ispyb/sp/shipping.py
@@ -24,7 +24,7 @@ class Shipping(ispyb.interface.shipping.IF):
     pass
 
   _dewar_params =\
-    StrictOrderedDict([('id',None), ('shippingId',None), ('name',None), ('comments',None), ('storageLocation',None),
+    StrictOrderedDict([('id',None), ('authLogin',None), ('shippingId',None), ('name',None), ('comments',None), ('storageLocation',None),
                          ('status',None), ('isStorageDewar',None), ('barCode',None), ('firstSessionId',None),
                          ('customsValue',None), ('transportValue',None), ('trackingNumberToSynchrotron',None),
                          ('trackingNumberFromSynchrotron',None), ('type',None),
@@ -44,8 +44,11 @@ class Shipping(ispyb.interface.shipping.IF):
 
   def upsert_dewar(self, values):
     '''Insert or update a dewar or parcel'''
-    return self.get_connection().call_sp_write('upsert_dewar', values)
+    return self.get_connection().call_sp_write('upsert_dewar_v2', values)
 
-  def retrieve_dewars_for_proposal_code_number(self, proposal_code, proposal_number):
+  def retrieve_dewars_for_proposal_code_number(self, proposal_code, proposal_number, auth_login=None):
     '''Get a result-set with the dewars associated with shipments in a given proposal specified by proposal code, proposal_number'''
-    return self.get_connection().call_sp_retrieve(procname='retrieve_dewars_for_proposal_code_number', args=(proposal_code, proposal_number))
+    return self.get_connection().call_sp_retrieve(
+      procname='retrieve_dewars_for_proposal_code_number_v2', 
+      args=(proposal_code, proposal_number, auth_login)
+    )

--- a/ispyb/sp/shipping.py
+++ b/ispyb/sp/shipping.py
@@ -36,7 +36,7 @@ class Shipping(ispyb.interface.shipping.IF):
 
   def update_container_assign(self, beamline, registry_barcode, position):
     '''Assign a container'''
-    self.get_connection().call_sp_write(procname='update_container_assign', args=(beamline, registry_barcode, position))
+    return self.get_connection().call_sp_retrieve(procname='update_container_assign', args=(beamline, registry_barcode, position))
 
   def update_container_unassign_all_for_beamline(self, beamline):
     '''Unassign all containers for a given beamline. Assumes container.sessionId and container.containerRegistryId are populated.'''

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -124,5 +124,10 @@ def test_retrieve_active_plates(testdb):
         assert len(rs) >= 0
 
 def test_retrieve_proposal_title(testdb):
-        title = testdb.core.retrieve_proposal_title('cm', 14451)
+        rs = testdb.core.retrieve_proposal_title('cm', 14451)
+        title = rs[0]['title']
+        assert title.strip() == 'I03 Commissioning Directory 2016'
+
+        rs = testdb.core.retrieve_proposal_title('cm', 14451, 'boaty')
+        title = rs[0]['title']
         assert title.strip() == 'I03 Commissioning Directory 2016'

--- a/tests/test_mxacquisition.py
+++ b/tests/test_mxacquisition.py
@@ -38,6 +38,9 @@ def test_mxacquisition_methods(testdb):
         rs = mxacquisition.retrieve_data_collection_main(id1)
         assert rs[0]['groupId'] == dcgid
 
+        rs = mxacquisition.retrieve_data_collection_main(id1, 'boaty')
+        assert rs[0]['groupId'] == dcgid
+
         dc = testdb.get_data_collection(id1)
         assert dc.image_count == 360
         assert dc.dcgid == dcgid
@@ -88,6 +91,9 @@ def test_mxacquisition_methods(testdb):
         assert gridinfo['snapshot_offsetYPixel'] == params['snapshotOffsetYPixel']
         assert gridinfo['steps_x'] == params['steps_x']
         assert gridinfo['steps_y'] == params['steps_y']
+
+        gridinfo = mxacquisition.retrieve_dcg_grid(dcgid, 'boaty')
+        assert len(gridinfo) == 1
 
         xray_cr_id = mxacquisition.upsert_xray_centring_result(
             grid_info_id=dcg_grid_id,

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -31,3 +31,5 @@ def test_upsert_dewar(testdb):
 def test_retrieve_dewars(testdb):
         rs = testdb.shipping.retrieve_dewars_for_proposal_code_number('cm', 1)
         assert len(rs) > 0
+        rs = testdb.shipping.retrieve_dewars_for_proposal_code_number('cm', 14451, 'boaty')
+        assert len(rs) > 0

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -2,9 +2,13 @@ from __future__ import absolute_import, division, print_function
 
 
 def test_update_container(testdb):
-        testdb.shipping.update_container_assign('i02-2', 'VMXiSim-001', 10)
+        rs = testdb.shipping.update_container_assign('i02-2', 'VMXiSim-001', 10)
+        assert len(rs) > 0
+        assert rs[0]['containerStatus'] in ('processing', 'at facility')
         testdb.shipping.update_container_unassign_all_for_beamline('i02-2')
-        testdb.shipping.update_container_assign('i02-2', 'VMXiSim-001', 10)
+        rs = testdb.shipping.update_container_assign('i02-2', 'VMXiSim-001', 10)
+        assert len(rs) > 0
+        assert rs[0]['containerStatus'] in ('processing', 'at facility')
         testdb.shipping.update_container_unassign_all_for_beamline('i02-2')
 
 def test_upsert_dewar(testdb):


### PR DESCRIPTION
Changes to support optional authorisation for relevant methods.

- "v2" of relevant SQL routines to support optional authorisation 
- Some SQL functions replaced by procedures 
- `auth_login` parameter (the username) for the Python methods corresponding to the SQL routines
- **Breaking change:** Note that the `retrieve_proposal_title` method now returns a result set (list of tuples) similar to other "retrieve" methods. 

Also, unrelated: modification of method & sproc `update_container_assign` to return the `containerId` and (new) `containerStatus` of the container found. 