### PR TITLE
Replace upsert_program with upsert_program_ex

### DIFF
--- a/docs/pipeline2ispyb.py
+++ b/docs/pipeline2ispyb.py
@@ -86,12 +86,13 @@ with ispyb.open(sys.argv[1]) as conn:
     print "scr_in_id: %i" % scr_in_id
 
     # Store results from XIA2 / MX data reduction pipelines
-    params = mxprocessing.get_program_params()
-    params['programs'] = 'xia2'
-    params['cmd_line'] = 'xia2 -3dii ........'
-    params['starttime'] = datetime.strptime('2014-09-24 14:30:01', '%Y-%m-%d %H:%M:%S')
-    params['updatetime'] = datetime.strptime('2014-09-24 14:30:27', '%Y-%m-%d %H:%M:%S')
-    app_id = mxprocessing.upsert_program(list(params.values()))
+    app_id = mxprocessing.upsert_program_ex(
+        job_id = job_id,
+        name = 'xia2',
+        command='xia2 -3dii ........',
+        time_start = datetime.strptime('2014-09-24 14:30:01', '%Y-%m-%d %H:%M:%S'),
+        time_update = datetime.strptime('2014-09-24 14:30:27', '%Y-%m-%d %H:%M:%S'),
+    )
     print "app_id: %i" % app_id
 
     # ...first the top-level processing entry

--- a/ispyb/interface/processing.py
+++ b/ispyb/interface/processing.py
@@ -7,10 +7,6 @@ from ispyb.interface.dataarea import DataArea
 class IF(DataArea):
 
   @abc.abstractmethod
-  def get_program_params(self):
-      pass
-
-  @abc.abstractmethod
   def get_program_attachment_params(self):
       pass
 

--- a/ispyb/sp/mxprocessing.py
+++ b/ispyb/sp/mxprocessing.py
@@ -15,10 +15,6 @@ from ispyb.strictordereddict import StrictOrderedDict
 class MXProcessing(ispyb.interface.processing.IF):
   '''MXProcessing provides methods to store MX processing data.'''
 
-  _program_params = StrictOrderedDict([('id',None), ('cmd_line',None), ('programs',None),
-    ('status',None), ('message',None), ('starttime',None), ('updatetime',None), ('environment',None), ('processing_job_id',None),
-    ('recordtime',None)])
-
   _program_attachment_params = StrictOrderedDict([('id',None), ('parentid', None), ('file_name',None), ('file_path',None), ('file_type',None)])
 
   _processing_params = StrictOrderedDict([('id',None), ('parentid',None), ('spacegroup',None),
@@ -70,10 +66,6 @@ class MXProcessing(ispyb.interface.processing.IF):
     return copy.deepcopy(cls._run_blob_params)
 
   @classmethod
-  def get_program_params(cls):
-    return copy.deepcopy(cls._program_params)
-
-  @classmethod
   def get_program_attachment_params(cls):
     return copy.deepcopy(cls._program_attachment_params)
 
@@ -118,12 +110,6 @@ class MXProcessing(ispyb.interface.processing.IF):
   @classmethod
   def get_job_image_sweep_params(cls):
      return copy.deepcopy(cls._job_image_sweep_params)
-
-  def upsert_program(self, values):
-    '''Store new or update existing program params.'''
-    import warnings
-    warnings.warn("Function upsert_program using the ordered dictionary parameter is deprecated and will be removed in the next release. Use the function upsert_program_ex instead.", DeprecationWarning)
-    return self.get_connection().call_sp_write(procname='upsert_processing_program', args=values) # doesn't work with dict cursors
 
   def upsert_program_ex(self, program_id=None, job_id=None, name=None,
       command=None, environment=None, message=None, status=None,

--- a/ispyb/xmltools.py
+++ b/ispyb/xmltools.py
@@ -129,14 +129,20 @@ def mx_data_reduction_to_ispyb(xmldict, dc_id = None, mxprocessing = None):
 
     # Store results from MX data reduction pipelines
     # ...first the program info
-    params = mxprocessing.get_program_params()
+    programs = None
+    command = None
+    job_id = None    
     if 'processingPrograms' in program:
-        params['programs'] = program['processingPrograms']
+        programs = program['processingPrograms']
     if 'processingCommandLine' in program:
-        params['cmd_line'] = program['processingCommandLine']
+        command = program['processingCommandLine']
     if 'reprocessingId' in program:
-        params['reprocessingid'] = program['reprocessingId']
-    app_id = mxprocessing.upsert_program(list(params.values()))
+        job_id = program['reprocessingId']
+    app_id = mxprocessing.upsert_program_ex(
+        job_id = job_id,
+        name = programs,
+        command=command,
+    )
 
     if attachments != None:
         params = mxprocessing.get_program_attachment_params()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,10 +10,10 @@ import pytest
 def test_multi_threads_upsert(testdb):
         mxprocessing = testdb.mx_processing
 
-        params = mxprocessing.get_program_params()
-        params['cmd_line'] = 'dials -xia2 /path/to/files'
-        params['message'] = 'Just started ...'
-        programid = mxprocessing.upsert_program(list(params.values()))
+        programid = mxprocessing.upsert_program_ex(
+          command='dials -xia2 /path/to/files',
+          message='Just started ...',
+        )
         assert programid is not None
 
         params_list = []

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -131,11 +131,13 @@ def test_processing1(testdb):
 def test_processing2(testdb):
         mxprocessing = testdb.mx_processing
 
-        params = mxprocessing.get_program_params()
-        params['cmd_line'] = 'ls -ltr'
-        params['message'] = 'Just started ...'
-        params['processing_job_id'] = 5
-        id = mxprocessing.upsert_program(list(params.values()))
+        command='ls -ltr'
+        message='Just started ...'
+        id = mxprocessing.upsert_program_ex(
+          job_id=5,
+          command=command,
+          message=message,
+        )
         assert id is not None
         assert id > 0
         print('id: %d' % id)
@@ -155,13 +157,16 @@ def test_processing2(testdb):
         assert programs
         program = programs[0]
         assert program.job_id == 5
-        assert program.command == params['cmd_line']
-        assert program.message == params['message']
+        assert program.command == command
+        assert program.message == message
 
-        params['id'] = id
-        params['status'] = True
-        params['message'] = 'Finished'
-        programid = mxprocessing.upsert_program(list(params.values()))
+        message = 'Finished'
+        programid = mxprocessing.upsert_program_ex(
+          program_id=id,
+          status=True,
+          command=command,
+          message=message,
+        )
         assert programid is not None
         assert programid > 0
 


### PR DESCRIPTION
As the `upsert_program` method was deprecated with a warning it would go away in version 5, here is an attempt at replacing it with `upsert_program_ex`.

 