### PR TITLE
New method retrive_sessions_for_beamline_and_run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ addons:
   mariadb: '10.2'
 
 before_install:
-- wget https://github.com/DiamondLightSource/ispyb-database/releases/download/v1.3.0/ispyb-database-1.3.0.tar.gz
-- tar xvfz ispyb-database-1.3.0.tar.gz
+- wget https://github.com/DiamondLightSource/ispyb-database/releases/download/v1.4.0/ispyb-database-1.4.0.tar.gz
+- tar xvfz ispyb-database-1.4.0.tar.gz
 - mysql_upgrade -u root
 - mysql -u root -e "CREATE DATABASE ispybtest; SET GLOBAL log_bin_trust_function_creators=ON;"
 - mysql -u root -D ispybtest < schema/tables.sql

--- a/ispyb/sp/core.py
+++ b/ispyb/sp/core.py
@@ -105,6 +105,10 @@ class Core(ispyb.interface.core.IF):
     '''Get a result-set with the currently active sessions on the given beamline.'''
     return self.get_connection().call_sp_retrieve(procname='retrieve_current_sessions', args=(beamline,tolerance_mins))
 
+  def retrieve_sessions_for_beamline_and_run(self, beamline, run):
+    '''Get a result-set with the sessions associated with the given beamline/instrument and run.'''
+    return self.get_connection().call_sp_retrieve(procname='retrieve_sessions_for_beamline_and_run', args=(beamline, run))
+
   def retrieve_sessions_for_person_login(self, login):
     '''Get a result-set with the sessions associated with the given unique person login.'''
     return self.get_connection().call_sp_retrieve(procname='retrieve_sessions_for_person_login', args=(login,))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -91,6 +91,10 @@ def test_retrieve_current_sessions(testdb):
         rs = testdb.core.retrieve_current_sessions('i03', 24*60*30000)
         assert len(rs) > 0
 
+def test_retrieve_sessions_for_beamline_and_run(testdb):
+        rs = testdb.core.retrieve_sessions_for_beamline_and_run('i03', '2016-01')
+        assert len(rs) > 0
+
 def test_retrieve_sessions_for_person_login(testdb):
         rs = testdb.core.retrieve_sessions_for_person_login('boaty')
         assert len(rs) > 0


### PR DESCRIPTION
A method to retrieve all sessions on a particular beamline/instrument and in a particular run. 