### PR TITLE
setup.py: replace enum-compat with enum34 for python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
 from setuptools import find_packages, setup
+import sys
+
+INSTALL_REQUIRES = ['mysql-connector<2.2.3']
+
+if sys.version_info.major == 2:
+    INSTALL_REQUIRES.append('enum34')
 
 setup(
     name="ispyb",
@@ -15,7 +21,7 @@ setup(
     packages=find_packages(),
     scripts=["bin/dimple2ispyb.py", "bin/mxdatareduction2ispyb.py"],
     license="Apache License, Version 2.0",
-    install_requires=["enum-compat", "mysql-connector<2.2.3"],
+    install_requires=INSTALL_REQUIRES,
     setup_requires=["pytest-runner"],
     tests_require=["mock", "pytest"],
     classifiers=[


### PR DESCRIPTION
@karllevik @anthchirp @jacobfilik

`enum-compat` is absent from the default and conda-forge channels. The conda-forge `ispyb` recipe adds `enum34` for python 2.7 to circumvent this, but fails to do so as shown by this error encountered when running zocalo.wrap:

```bash
$ zocalo.wrap --wrap generic_process
Traceback (most recent call last):
  File "/dls_sw/apps/python/anaconda/4.6.14/64/envs/zocalo-stable/bin/zocalo.wrap", line 12, in <module>
    sys.exit(run())
  File "/dls_sw/apps/python/anaconda/4.6.14/64/envs/zocalo-stable/lib/python3.7/site-packages/zocalo/cli/wrap.py", line 129, in run
    instance = known_wrappers[options.wrapper]()()
  File "/dls_sw/apps/python/anaconda/4.6.14/64/envs/zocalo-stable/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2433, in load
    self.require(*args, **kwargs)
  File "/dls_sw/apps/python/anaconda/4.6.14/64/envs/zocalo-stable/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2456, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/dls_sw/apps/python/anaconda/4.6.14/64/envs/zocalo-stable/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'enum-compat' distribution was not found and is required by ispyb

```

This patch fixes the problem by explicitly adding enum34 as an installation requirement to setup.py, when installing on python 2.7.