### PR TITLE
Samples not yet loaded for registered container barcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ addons:
   mariadb: '10.2'
 
 before_install:
-- wget https://github.com/DiamondLightSource/ispyb-database/releases/download/v1.5.2/ispyb-database-1.5.2.tar.gz
-- tar xvfz ispyb-database-1.5.2.tar.gz
+- wget https://github.com/DiamondLightSource/ispyb-database/releases/download/v1.6.0/ispyb-database-1.6.0.tar.gz
+- tar xvfz ispyb-database-1.6.0.tar.gz
 - mysql_upgrade -u root
 - mysql -u root -e "CREATE DATABASE ispybtest; SET GLOBAL log_bin_trust_function_creators=ON;"
 - mysql -u root -D ispybtest < schema/tables.sql

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+5.3.0 (2019-08-15)
+------------------
+
+New method:
+
+  * retrieve_samples_not_loaded_for_container_reg_barcode, `#85 <https://github.com/DiamondLightSource/ispyb-api/pull/85>`_
+
 5.2.0 (2019-06-17)
 ------------------
 

--- a/ispyb/sp/core.py
+++ b/ispyb/sp/core.py
@@ -154,6 +154,13 @@ class Core(ispyb.interface.core.IF):
             procname="upsert_sample", args=values
         )
 
+    def retrieve_samples_not_loaded_for_container_reg_barcode(self, barcode):
+        """Retrieve the not-yet loaded samples in the most recent container that corresponds with the given container registry barcode"""
+        return self.get_connection().call_sp_retrieve(
+            procname="retrieve_samples_not_loaded_for_container_reg_barcode",
+            args=(barcode,),
+        )
+
     def retrieve_visit_id(self, visit):
         """Get the database ID for a visit on the form mx1234-5."""
         return self.get_connection().call_sf_retrieve(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -69,6 +69,12 @@ def test_insert_session_for_proposal_code_number(testdb):
     assert phpid > 0
 
 
+def test_retrieve_samples_not_loaded_for_container_reg_barcode(testdb):
+    core = testdb.core
+    rs = core.retrieve_samples_not_loaded_for_container_reg_barcode("DLS-0001")
+    assert len(rs) > 0
+
+
 def test_upsert_sample(testdb):
     core = testdb.core
     params = core.get_sample_params()


### PR DESCRIPTION
Adds a method retrieve_samples_not_loaded_for_container_reg_barcode.