### PR TITLE
Add object model for ImageQualityIndicators

### DIFF
--- a/ispyb/model/datacollection.py
+++ b/ispyb/model/datacollection.py
@@ -55,6 +55,12 @@ class DataCollection(ispyb.model.DBCache):
         raise NotImplementedError("TODO: Not implemented yet")
 
     @property
+    def image_quality(self):
+        """Returns the list of ImageQualityIndicators objects associated with
+        this DC."""
+        raise NotImplementedError("TODO: Not implemented yet")
+
+    @property
     def file_template_full(self):
         """Template for file names with full directory path. As with file_template
         \'#\' characters stand in for image number digits."""

--- a/ispyb/model/image_quality_indicators.py
+++ b/ispyb/model/image_quality_indicators.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+import tabulate
+
 import ispyb.model
 
 
@@ -41,6 +43,28 @@ class ImageQualityIndicators(ispyb.model.DBCache):
     def image_number(self):
         """Returns the ImageNumber."""
         return self._image_number
+
+    def __str__(self):
+        """Returns a pretty-printed object representation."""
+        if not self.cached:
+            return (
+                "ImageQualityIndicators dcid: %d, imageNumber: %d (not yet loaded from database)"
+                % (self._dcid, self._image_number)
+            )
+        return (
+            "\n".join(
+                (
+                    "ImageQualityIndicators",
+                    "  dcid                    : {0.dcid}",
+                    "  image_number            : {0.image_number}",
+                    "  spot_count              : {0.spot_count}",
+                    "  bragg_candidates        : {0.bragg_candidates}",
+                    "  resolution_method_1     : {0.resolution_method_1}",
+                    "  resolution_method_2     : {0.resolution_method_2}",
+                    "  total_integrated_signal : {0.total_integrated_signal}",
+                )
+            )
+        ).format(self)
 
 
 ispyb.model.add_properties(
@@ -98,3 +122,19 @@ class ImageQualityIndicatorsList(ispyb.model.DBCache, collections.Sequence):
         return ImageQualityIndicators(
             self._dcid, data["imageNumber"], self._db, preload=data
         )
+
+    def __str__(self):
+        """Returns a pretty-printed object representation."""
+        headers = (
+            "dcid",
+            "image_number",
+            "spot_count",
+            "bragg_candidates",
+            "resolution_method_1",
+            "resolution_method_2",
+            "total_integrated_signal",
+        )
+        rows = []
+        for qi in self:
+            rows.append([getattr(qi, k) for k in headers])
+        return tabulate(rows, headers=headers, tablefmt="psql")

--- a/ispyb/model/image_quality_indicators.py
+++ b/ispyb/model/image_quality_indicators.py
@@ -1,0 +1,100 @@
+from __future__ import absolute_import, division, print_function
+
+import ispyb.model
+
+
+class ImageQualityIndicators(ispyb.model.DBCache):
+    """An object representing an ImageQualityIndicators database entry.
+    The object lazily accesses the underlying database when necessary and
+    exposes record data as python attributes.
+    """
+
+    def __init__(self, dcid, image_number, db_conn, preload=None):
+        """Create an ImageQualityIndicators object for a given combination of
+        DataCollectionId and ImageNumber.
+
+        Requires a database connection object exposing further data access
+        methods.
+
+        :param dcid: DataCollectionId
+        :param image_number: ImageNumber
+        :param db_conn: ISPyB database connection object
+        :return: An ImageQualityIndicators object representing the database
+                 entry for the specified DataCollectionId and ImageNumber
+        """
+        self._db = db_conn
+        self._dcid = int(dcid)
+        self._image_number = int(image_number)
+        if preload:
+            self._data = preload
+
+    def reload(self):
+        """Load/update information from the database."""
+        raise NotImplementedError()
+
+    @property
+    def dcid(self):
+        """Returns the DataCollectionId."""
+        return self._dcid
+
+    @property
+    def image_number(self):
+        """Returns the ImageNumber."""
+        return self._image_number
+
+
+ispyb.model.add_properties(
+    ImageQualityIndicators,
+    (
+        ("spot_count", "spotTotal"),
+        ("bragg_candidates", "goodBraggCandidates"),
+        ("resolution_method_1", "method1Res"),
+        ("resolution_method_2", "method2Res"),
+        ("total_integrated_signal", "totalIntegratedSignal"),
+    ),
+)
+
+import collections
+
+
+class ImageQualityIndicatorsList(ispyb.model.DBCache, collections.Sequence):
+    """An object representing a list of  ImageQualityIndicators database entries.
+    The object lazily accesses the underlying database when necessary and
+    exposes record data as python attributes.
+    """
+
+    def __init__(self, dcid, db_conn, preload=None):
+        """Create an ImageQualityIndicators object for a given combination of
+        DataCollectionId and ImageNumber.
+
+        Requires a database connection object exposing further data access
+        methods.
+
+        :param dcid: DataCollectionId
+        :param image_number: ImageNumber
+        :param db_conn: ISPyB database connection object
+        :return: An ImageQualityIndicators object representing the database
+                 entry for the specified DataCollectionId and ImageNumber
+        """
+        self._db = db_conn
+        self._dcid = int(dcid)
+        if preload:
+            self._data = preload
+
+    def reload(self):
+        """Load/update information from the database."""
+        raise NotImplementedError()
+
+    @property
+    def dcid(self):
+        """Returns the DataCollectionId."""
+        return self._dcid
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getitem__(self, i):
+        data = self._data[i]
+        return ImageQualityIndicators(
+            self._dcid, data["imageNumber"], self._db, preload=data
+        )

--- a/ispyb/model/image_quality_indicators.py
+++ b/ispyb/model/image_quality_indicators.py
@@ -137,4 +137,4 @@ class ImageQualityIndicatorsList(ispyb.model.DBCache, collections.Sequence):
         rows = []
         for qi in self:
             rows.append([getattr(qi, k) for k in headers])
-        return tabulate(rows, headers=headers, tablefmt="psql")
+        return tabulate.tabulate(rows, headers=headers, tablefmt="psql")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from setuptools import find_packages, setup
 import sys
 
-INSTALL_REQUIRES = ["mysql-connector-python"]
+INSTALL_REQUIRES = ["mysql-connector-python", "tabulate"]
 
 if sys.version_info.major == 2:
     INSTALL_REQUIRES.append("enum34")

--- a/tests/model/test_image_quality_indicators.py
+++ b/tests/model/test_image_quality_indicators.py
@@ -14,6 +14,18 @@ def test_image_quality_indicators(testdb, testconfig):
     assert qi.resolution_method_2 == 1.63
     assert qi.spot_count == 1132
     assert qi.total_integrated_signal == 2.09
+    assert (
+        str(qi)
+        == """\
+ImageQualityIndicators
+  dcid                    : 1066786
+  image_number            : 1
+  spot_count              : 1132
+  bragg_candidates        : 872
+  resolution_method_1     : 1.63
+  resolution_method_2     : 1.63
+  total_integrated_signal : 2.09"""
+    )
 
 
 def test_image_quality_indicators_list(testdb, testconfig):
@@ -25,6 +37,17 @@ def test_image_quality_indicators_list(testdb, testconfig):
     assert len(qi_list) == 3
     for i, qi in enumerate(qi_list):
         assert qi.image_number == (i + 1)
+    assert (
+        str(qi_list)
+        == """\
++---------+----------------+--------------+--------------------+-----------------------+-----------------------+---------------------------+
+|    dcid |   image_number |   spot_count |   bragg_candidates |   resolution_method_1 |   resolution_method_2 |   total_integrated_signal |
+|---------+----------------+--------------+--------------------+-----------------------+-----------------------+---------------------------|
+| 1066786 |              1 |         1132 |                872 |                  1.63 |                  1.63 |                      2.09 |
+| 1066786 |              2 |          848 |                652 |                  1.56 |                  1.56 |                      2.03 |
+| 1066786 |              3 |          922 |                735 |                  1.57 |                  1.57 |                      2.13 |
++---------+----------------+--------------+--------------------+-----------------------+-----------------------+---------------------------+"""
+    )
 
 
 def test_dc_image_quality(testdb, testconfig):

--- a/tests/model/test_image_quality_indicators.py
+++ b/tests/model/test_image_quality_indicators.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import, division, print_function
+import ispyb.model.datacollection
+import ispyb.model.image_quality_indicators
+import ispyb.model.__future__
+
+
+def test_image_quality_indicators(testdb, testconfig):
+    ispyb.model.__future__.enable(testconfig)
+    qi = ispyb.model.image_quality_indicators.ImageQualityIndicators(1066786, 1, testdb)
+    qi.load()
+    assert qi.dcid == 1066786
+    assert qi.image_number == 1
+    assert qi.resolution_method_1 == 1.63
+    assert qi.resolution_method_2 == 1.63
+    assert qi.spot_count == 1132
+    assert qi.total_integrated_signal == 2.09
+
+
+def test_image_quality_indicators_list(testdb, testconfig):
+    ispyb.model.__future__.enable(testconfig)
+    qi_list = ispyb.model.image_quality_indicators.ImageQualityIndicatorsList(
+        1066786, testdb
+    )
+    qi_list.load()
+    assert len(qi_list) == 3
+    for i, qi in enumerate(qi_list):
+        assert qi.image_number == (i + 1)
+
+
+def test_dc_image_quality(testdb, testconfig):
+    ispyb.model.__future__.enable(testconfig)
+    dc = testdb.get_data_collection(1066786)
+    assert len(dc.image_quality) == dc.image_count
+    for i, qi in enumerate(dc.image_quality):
+        assert qi.image_number == (i + 1)


### PR DESCRIPTION
Add a `dc.image_quality` to `ispyb.model.data_collection.DataCollection` which returns an `ImageQualityIndicatorsList` object. This can then be iterated over to obtain the individual `ImageQualityIndicators` object corresponding to the database entry for each image.
