### PR TITLE
Add a container model object

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,12 @@ History
 Unreleased / master
 -------------------
 
+5.6.1 (2020-03-30)
+------------------
+
+* Added method to retrieve container for a given sample ID `#98 <https://github.com/DiamondLightSource/ispyb-api/pull/98>`_
+* Add object model for containers
+
 5.6.0 (2020-02-05)
 ------------------
 

--- a/ispyb/model/container.py
+++ b/ispyb/model/container.py
@@ -1,0 +1,71 @@
+from __future__ import absolute_import, division, print_function
+
+import ispyb
+import ispyb.model
+
+
+class Container(ispyb.model.DBCache):
+    """An object representing a Container database entry. The object
+    lazily accesses the underlying database when necessary and exposes record
+    data as python attributes.
+    """
+
+    def __init__(self, containerid, db_conn, preload=None):
+        """Create a Container object for a defined ContainerID. Requires
+        a database connection object exposing further data access methods.
+
+        :param containerid: ContainerID
+        :param db_conn: ISPyB database connection object
+        :return: A Container object representing the database entry for
+                 the specified ContainerID
+        """
+        self._db = db_conn
+        self._containerid = int(containerid)
+        if preload:
+            self._data = preload
+
+    def reload(self):
+        """Load/update information from the database."""
+        raise NotImplementedError("Loading containers is not currently supported")
+
+    @property
+    def containerid(self):
+        """Returns the ID associated with this container information."""
+        return self._containerid
+
+    def __bool__(self):
+        """Container object evaluates to True in a boolean context if grid
+        information exists in the database. Otherwise it evaluates to False."""
+        self.load()
+        return self._data is not None
+
+    __nonzero__ = __bool__  # Python 2 compatibility
+
+    def __repr__(self):
+        """Returns an object representation, including the ContainerID,
+        the database connection interface object, and the cache status."""
+        return "<Container #%d (%s), %r>" % (
+            self._containerid,
+            "cached" if self.cached else "uncached",
+            self._db,
+        )
+
+    def __str__(self):
+        """Returns a pretty-printed object representation."""
+        if not self.cached:
+            return "Container #%d (not yet loaded from database)" % self._containerid
+        return ("\n".join(("Container #{0.containerid}",))).format(self)
+
+
+ispyb.model.add_properties(
+    Container,
+    (
+        ("owner_given_name", "ownerGivenName", "Given name of the container owner"),
+        ("owner_family_name", "ownerFamilyName", "Family name of the container owner"),
+        (
+            "priority_processing",
+            "processingPipelineName",
+            "Selected priority processing pipeline",
+        ),
+    ),
+)

--- a/ispyb/model/datacollection.py
+++ b/ispyb/model/datacollection.py
@@ -227,6 +227,10 @@ class DataCollectionGroup(ispyb.model.DBCache):
         """Returns the container information for the DataCollectionGroup sample."""
         if self._cache_container is None:
             self.load()
+            if not self._data["sampleId"]:
+                # Can not have a container without a sample
+                self._cache_container = False
+                return self._cache_container
             container = self._db.shipping.retrieve_container_for_sample_id(
                 self._data["sampleId"]
             )

--- a/ispyb/model/datacollection.py
+++ b/ispyb/model/datacollection.py
@@ -4,6 +4,7 @@ import os
 import re
 
 import ispyb.model
+import ispyb.model.container
 import ispyb.model.gridinfo
 
 
@@ -196,6 +197,7 @@ class DataCollectionGroup(ispyb.model.DBCache):
         :return: A DataCollectionGroup object representing the database entry for
                  the specified DataCollectionGroupID
         """
+        self._cache_container = None
         self._cache_gridinfo = None
         self._db = db_conn
         self._dcgid = int(dcgid)
@@ -219,6 +221,22 @@ class DataCollectionGroup(ispyb.model.DBCache):
         if self._cache_gridinfo is None:
             self._cache_gridinfo = ispyb.model.gridinfo.GridInfo(self.dcgid, self._db)
         return self._cache_gridinfo
+
+    @property
+    def container(self):
+        """Returns the container information for the DataCollectionGroup sample."""
+        if self._cache_container is None:
+            self.load()
+            container = self._db.shipping.retrieve_container_for_sample_id(
+                self._data["sampleId"]
+            )
+            if not container:
+                self._cache_container = False
+            else:
+                self._cache_container = ispyb.model.container.Container(
+                    container[0]["containerId"], self._db, preload=container[0]
+                )
+        return self._cache_container
 
     def __repr__(self):
         """Returns an object representation, including the DataCollectionGroupID,


### PR DESCRIPTION
Bit of an odd one as it currently only works when populated via a `DataCollectionGroup`.
Only exposes three properties at this time.

Updated history file for 5.6.1 release later today.