### PR TITLE
Add ispyb.model.samplegroup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ addons:
   mariadb: 10.3
 
 before_install:
-- wget https://github.com/DiamondLightSource/ispyb-database/releases/download/v1.11.1/ispyb-database-1.11.1.tar.gz
-- tar xvfz ispyb-database-1.11.1.tar.gz
+- wget https://github.com/DiamondLightSource/ispyb-database/releases/download/v1.13.1/ispyb-database-1.13.1.tar.gz
+- tar xvfz ispyb-database-1.13.1.tar.gz
 - mysql_upgrade -u root
 - mysql -u root -e "CREATE DATABASE ispybtest; SET GLOBAL log_bin_trust_function_creators=ON;"
 - mysql -u root -D ispybtest < schema/tables.sql

--- a/ispyb/model/__future__.py
+++ b/ispyb/model/__future__.py
@@ -480,6 +480,7 @@ def _get_detector(self):
 
 
 def _get_sample_group(self):
+    # https://jira.diamond.ac.uk/browse/SCI-9379
     with _db_cc() as cursor:
         cursor.run(
             "SELECT blSampleGroupId, name "
@@ -510,6 +511,7 @@ def _get_sample_group(self):
 
 @property
 def _get_linked_sample_groups_for_dcid(self):
+    # https://jira.diamond.ac.uk/browse/SCI-9380
     import ispyb.model.samplegroup
 
     with _db_cc() as cursor:

--- a/ispyb/model/__future__.py
+++ b/ispyb/model/__future__.py
@@ -158,6 +158,13 @@ def enable(configuration_file, section="ispyb"):
 
     ispyb.model.detector.Detector.reload = _get_detector
 
+    import ispyb.model.samplegroup
+
+    ispyb.model.samplegroup.SampleGroup.reload = _get_sample_group
+    ispyb.model.datacollection.DataCollection.sample_groups = (
+        _get_linked_sample_groups_for_dcid
+    )
+
 
 def _get_autoprocprogram(self):
     # https://jira.diamond.ac.uk/browse/SCI-7414
@@ -470,6 +477,53 @@ def _get_detector(self):
             self._detectorid,
         )
         self._data = cursor.fetchone()
+
+
+def _get_sample_group(self):
+    with _db_cc() as cursor:
+        cursor.run(
+            "SELECT blSampleGroupId, name "
+            "FROM BLSampleGroup "
+            "WHERE blSampleGroupId = %s",
+            self.id,
+        )
+        self._data = cursor.fetchone()
+
+        # Get the samples belonging to this sample group
+        cursor.run(
+            "SELECT blSampleId FROM BLSampleGroup_has_BLSample "
+            "WHERE blSampleGroupId = %s "
+            "ORDER BY blSampleId",
+            self._data["blSampleGroupId"],
+        )
+        self._data["sample_ids"] = [row["blSampleId"] for row in cursor.fetchall()]
+
+        # Get the dcids associated with this sample group
+        cursor.run(
+            "SELECT dataCollectionId "
+            "FROM DataCollection "
+            "WHERE BLSAMPLEID in (%s) ",
+            ",".join(str(i) for i in self._data["sample_ids"]),
+        )
+        self._data["dcids"] = [row["dataCollectionId"] for row in cursor.fetchall()]
+
+
+@property
+def _get_linked_sample_groups_for_dcid(self):
+    import ispyb.model.samplegroup
+
+    with _db_cc() as cursor:
+        cursor.run(
+            "SELECT b.blSampleGroupId as blSampleGroupId "
+            "FROM BLSampleGroup_has_BLSample b "
+            "INNER JOIN DataCollection d ON b.blSampleId = d.BLSAMPLEID "
+            "WHERE dataCollectionId = %s",
+            self._dcid,
+        )
+        return [
+            ispyb.model.samplegroup.SampleGroup(row["blSampleGroupId"], self._db)
+            for row in cursor.fetchall()
+        ]
 
 
 def test_connection():

--- a/ispyb/model/datacollection.py
+++ b/ispyb/model/datacollection.py
@@ -64,6 +64,11 @@ class DataCollection(ispyb.model.DBCache):
         raise NotImplementedError("TODO: Not implemented yet")
 
     @property
+    def sample_groups(self):
+        """Returns the list of SampleGroups associated with this DC."""
+        raise NotImplementedError("TODO: Not implemented yet")
+
+    @property
     def detector(self):
         """Returns the Detector object associated with this DC."""
         if not self.detector_id:

--- a/ispyb/model/samplegroup.py
+++ b/ispyb/model/samplegroup.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import, division, print_function
+
+import ispyb.model
+
+
+class SampleGroup(ispyb.model.DBCache):
+    def __init__(self, sample_group_id, db_conn, preload=None):
+        """Create a SampleGroup object for a defined sample_group_id. Requires
+        a database connection object exposing further data access methods.
+
+        :param sample_group_id: bLSampleGroupId
+        :param db_conn: ISPyB database connection object
+        :return: A SampleGroup object representing the database entry for
+                 the specified bLSampleGroupId
+        """
+        self._db = db_conn
+        self._id = int(sample_group_id)
+        if preload:
+            self._data = preload
+
+    def reload(self):
+        """Load/update information from the database."""
+        raise NotImplementedError()
+
+    @property
+    def id(self):
+        "Returns the detectorId"
+        return self._id
+
+    def __str__(self):
+        """Returns a pretty-printed object representation."""
+        if not self.cached:
+            return "SampleGroup #%d (not yet loaded from database)" % self._id
+        return (
+            "\n".join(
+                (
+                    "SampleGroup #%s" % self._id,
+                    "  Name       : %s" % self.name,
+                    "  Sample ids : %s"
+                    % (
+                        ",".join(str(i) for i in self.sample_ids)
+                        if self.sample_ids
+                        else "None"
+                    ),
+                    "  DCIDs      : %s"
+                    % (",".join(str(i) for i in self.dcids) if self.dcids else "None"),
+                )
+            )
+        ).format(self)
+
+
+ispyb.model.add_properties(
+    SampleGroup,
+    (
+        ("name", "name", "The SampleGroup name"),
+        ("sample_ids", "sample_ids", "The sample ids comprising the sample group"),
+        ("dcids", "dcids", "The data collection ids associated with this sample group"),
+    ),
+)

--- a/tests/model/test_samplegroup.py
+++ b/tests/model/test_samplegroup.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, division, print_function
+import ispyb.model.datacollection
+import ispyb.model.samplegroup
+import ispyb.model.__future__
+
+
+def test_dc_no_sample_groups(testdb, testconfig):
+    ispyb.model.__future__.enable(testconfig)
+    dc = testdb.get_data_collection(1052503)
+    assert len(dc.sample_groups) == 0
+
+
+def test_dc_sample_groups(testdb, testconfig):
+    ispyb.model.__future__.enable(testconfig)
+    dc = testdb.get_data_collection(1066786)
+    assert len(dc.sample_groups) == 1
+    assert dc.sample_groups[0].dcids == [dc.dcid]
+
+
+def test_sample_group_no_linked_dcids(testdb, testconfig):
+    ispyb.model.__future__.enable(testconfig)
+    sample_group = ispyb.model.samplegroup.SampleGroup(5, testdb)
+    assert str(sample_group) == "SampleGroup #5 (not yet loaded from database)"
+    sample_group.reload()
+    assert sample_group.sample_ids == [398824, 398827]
+    assert len(sample_group.dcids) == 0
+    assert (
+        str(sample_group)
+        == """\
+SampleGroup #5
+  Name       : None
+  Sample ids : 398824,398827
+  DCIDs      : None\
+"""
+    )
+
+
+def test_sample_group_linked_dcids(testdb, testconfig):
+    ispyb.model.__future__.enable(testconfig)
+    sample_group = ispyb.model.samplegroup.SampleGroup(6, testdb)
+    sample_group.reload()
+    assert sample_group.sample_ids == [398810]
+    assert sample_group.name == "foo"
+    assert sample_group.dcids == [1066786]
+    assert (
+        str(sample_group)
+        == """\
+SampleGroup #6
+  Name       : foo
+  Sample ids : 398810
+  DCIDs      : 1066786\
+"""
+    )


### PR DESCRIPTION
New ispyb.model.samplegroup.SampleGroup model. Provides access to
associated sample ids and dcids.

New property DataCollection.sample_groups which returns a list of
SampleGroup objects associated with the current DataCollection.