### PR TITLE
New method to insert a subsample for a given sample image full path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ addons:
   mariadb: 10.3
 
 before_install:
-- wget -t 3 -w 60 --random-wait https://github.com/DiamondLightSource/ispyb-database/releases/download/v1.15.1/ispyb-database-1.15.1.tar.gz
-- tar xvfz ispyb-database-1.15.1.tar.gz
+- wget -t 3 -w 60 --random-wait https://github.com/DiamondLightSource/ispyb-database/releases/download/v1.17.2/ispyb-database-1.17.2.tar.gz
+- tar xvfz ispyb-database-1.17.2.tar.gz
 - mysql_upgrade -u root
 - mysql -u root -e "CREATE DATABASE ispybtest; SET GLOBAL log_bin_trust_function_creators=ON;"
-- mysql -u root -D ispybtest < schema/tables.sql
-- mysql -u root -D ispybtest < schema/lookups.sql
-- mysql -u root -D ispybtest < schema/data.sql
-- mysql -u root -D ispybtest < schema/routines.sql
+- mysql -u root -D ispybtest < schemas/ispyb/tables.sql
+- mysql -u root -D ispybtest < schemas/ispyb/lookups.sql
+- mysql -u root -D ispybtest < schemas/ispyb/data.sql
+- mysql -u root -D ispybtest < schemas/ispyb/routines.sql
 - mysql -u root -D ispybtest < grants/ispyb_processing.sql
 - mysql -u root -D ispybtest < grants/ispyb_import.sql
 - mysql -u root -e "CREATE USER ispyb_api@'localhost' IDENTIFIED BY 'password_1234'; GRANT ispyb_processing to ispyb_api@'localhost'; GRANT ispyb_import to ispyb_api@'localhost'; SET DEFAULT ROLE ispyb_processing FOR ispyb_api@'localhost';"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ History
 
 Unreleased / master
 -------------------
+5.9.0 (2021-01-14)
+------------------
+
+* New method insert_subsample_for_image_full_path `#114 <https://github.com/DiamondLightSource/ispyb-api/pull/114>`_ (requires ispyb-database 1.17.2)
 
 5.8.1 (2020-11-22)
 ------------------

--- a/ispyb/sp/xtalimaging.py
+++ b/ispyb/sp/xtalimaging.py
@@ -58,10 +58,12 @@ class XtalImaging(DataArea):
         position2x=None,
         position2y=None,
     ):
-        """Store new subsample for a given sample image. Either specify a point
-        (by providing position1x and position1y) or a ROI box (by additionally
-        providing position2x and position2y). Position coordinates are given in
-        pixels from the top-left corner of the image.
+        """Store new subsample for a given sample image.
+        
+        Either specify a point (by providing position1x and position1y)
+        or a ROI box (by additionally providing position2x and position2y).
+        Position coordinates are given in pixels from the top-left corner
+        of the image.
 
         :param image_full_path: The full path to the sample image
         :type image_full_path: str

--- a/ispyb/sp/xtalimaging.py
+++ b/ispyb/sp/xtalimaging.py
@@ -49,6 +49,38 @@ class XtalImaging(DataArea):
             args=[image_full_path, schema_name, score_class, probability],
         )
 
+    def insert_subsample_for_image_full_path(
+        self,
+        image_full_path,
+        source,
+        position1x,
+        position1y,
+        position2x=None,
+        position2y=None,
+    ):
+        """Store new subsample for a given sample image.
+
+        :param image_full_path: The full path to the sample image
+        :param source: manual or auto
+        :param position1x:
+        :param position1y:
+        :param position2x:
+        :param position2y:
+        """
+        id = None
+        return self.get_connection().call_sp_write(
+            procname="insert_subsample_for_image_full_path",
+            args=[
+                id,
+                image_full_path,
+                source,
+                position1x,
+                position1y,
+                position2x,
+                position2y,
+            ],
+        )
+
     def retrieve_container_for_barcode(self, barcode):
         """Retrieve info about the container indetified by the give barcode."""
         return self.get_connection().call_sp_retrieve(

--- a/ispyb/sp/xtalimaging.py
+++ b/ispyb/sp/xtalimaging.py
@@ -58,14 +58,26 @@ class XtalImaging(DataArea):
         position2x=None,
         position2y=None,
     ):
-        """Store new subsample for a given sample image.
+        """Store new subsample for a given sample image. Either specify a point
+        (by providing position1x and position1y) or a ROI box (by additionally
+        providing position2x and position2y). Position coordinates are given in
+        pixels from the top-left corner of the image.
 
         :param image_full_path: The full path to the sample image
+        :type image_full_path: str
         :param source: manual or auto
-        :param position1x: x component of position, or if position2x,y given, then x component of top left corner of ROI box
-        :param position1y: y component of position, or if position2x,y given, then y component of top left corner of ROI box
-        :param position2x: x component of lower right corner of ROI box
-        :param position2y: y component of lower right corner of ROI box
+        :type source: str
+        :param position1x: x component of position1
+        :type position1x: int
+        :param position1y: y component of position1
+        :type position1y: int
+        :param position2x: x component of position2 which is the lower right
+        corner of a ROI box
+        :type position2x: int
+        :param position2y: y component of position2 which is the lower right
+        corner of a ROI box
+        :type position2y: int
+        :return: The subsample_id.
         """
         id = None
         return self.get_connection().call_sp_write(

--- a/ispyb/sp/xtalimaging.py
+++ b/ispyb/sp/xtalimaging.py
@@ -62,10 +62,10 @@ class XtalImaging(DataArea):
 
         :param image_full_path: The full path to the sample image
         :param source: manual or auto
-        :param position1x:
-        :param position1y:
-        :param position2x:
-        :param position2y:
+        :param position1x: x component of position, or if position2x,y given, then x component of top left corner of ROI box
+        :param position1y: y component of position, or if position2x,y given, then y component of top left corner of ROI box
+        :param position2x: x component of lower right corner of ROI box
+        :param position2y: y component of lower right corner of ROI box
         """
         id = None
         return self.get_connection().call_sp_write(

--- a/tests/test_xtalimaging.py
+++ b/tests/test_xtalimaging.py
@@ -37,3 +37,21 @@ def test_xtal_imaging(testdb):
 
     assert cid2 is not None
     assert cid2 == 34874
+
+    ssid = xtalimaging.insert_subsample_for_image_full_path(
+        image_full_path=si_full_path,
+        source="auto",
+        position1x=3.04,
+        position1y=6.13,
+    )
+    assert ssid is not None
+
+    ssid2 = xtalimaging.insert_subsample_for_image_full_path(
+        image_full_path=si_full_path,
+        source="auto",
+        position1x=3.04,
+        position1y=6.13,
+        position2x=4.5,
+        position2y=7.8,
+    )
+    assert ssid2 is not None

--- a/tests/test_xtalimaging.py
+++ b/tests/test_xtalimaging.py
@@ -41,17 +41,17 @@ def test_xtal_imaging(testdb):
     ssid = xtalimaging.insert_subsample_for_image_full_path(
         image_full_path=si_full_path,
         source="auto",
-        position1x=3.04,
-        position1y=6.13,
+        position1x=304,
+        position1y=621,
     )
     assert ssid is not None
 
     ssid2 = xtalimaging.insert_subsample_for_image_full_path(
         image_full_path=si_full_path,
         source="auto",
-        position1x=3.04,
-        position1y=6.13,
-        position2x=4.5,
-        position2y=7.8,
+        position1x=391,
+        position1y=687,
+        position2x=473,
+        position2y=744,
     )
     assert ssid2 is not None


### PR DESCRIPTION
This PR includes:

- New method `insert_subsample_for_image_full_path` in the `XtalImaging` class
- Tests for the new method
- Update `.travis.yml` file to use ispyb-database v1.17.2
- Updated `HISTORY.rst` file with details for planned new version 5.9.0 