### PR TITLE
Fix broken database queries

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@ History
 
 Unreleased / master
 -------------------
+5.9.1 (2021-01-25)
+------------------
+
+* Fix compatibility issue with newer versions of mysql-connector
+
 5.9.0 (2021-01-14)
 ------------------
 

--- a/ispyb/connector/mysqlsp/main.py
+++ b/ispyb/connector/mysqlsp/main.py
@@ -123,7 +123,10 @@ class ISPyBMySQLSPConnector(ispyb.interface.connection.IF):
             for recordset in cursor.stored_results():
                 if isinstance(cursor, mysql.connector.cursor.MySQLCursorDict):
                     for row in recordset:
-                        result.append(dict(list(zip(recordset.column_names, row))))
+                        if isinstance(row, dict):
+                            result.append(row)
+                        else:
+                            result.append(dict(list(zip(recordset.column_names, row))))
                 else:
                     result = recordset.fetchall()
 


### PR DESCRIPTION
Apparently, the `MySQLCursorDict` can now return dictionaries instead of tuples.

I'm not going to pretend I understand how this code worked for many years, but it looks like historically the `MySQLCursorDict` tended to return tuples...

In any case, with newer versions of mysql-connector things stopped working.