### PR TITLE
Drop support for Python 2.7 and 3.5

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -95,10 +95,6 @@ stages:
       vmImage: ubuntu-20.04
     strategy:
       matrix:
-        python27:
-          PYTHON_VERSION: 2.7
-        python35:
-          PYTHON_VERSION: 3.5
         python36:
           PYTHON_VERSION: 3.6
         python37:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ as webservices.
 Please see https://ispyb.readthedocs.io.
 
 ### Requirements
-* Python 2.7, 3.5, 3.6, 3.7, 3.8
+* Python 3.6, 3.7, 3.8
 * The MySQL Connector/Python package.
 * MariaDB 10.0+ or MySQL 5.6+, but we recommend MariaDB 10.2 or later.
 * An ISPyB database installed on the above. See the [ispyb-database](https://github.com/DiamondLightSource/ispyb-database) repo for details.

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,3 @@ replace = version="{new_version}"
 [bumpversion:file:ispyb/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
-
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,8 @@
 from __future__ import absolute_import, division, print_function
 
 from setuptools import find_packages, setup
-import sys
 
 INSTALL_REQUIRES = ["mysql-connector-python", "tabulate"]
-
-if sys.version_info.major == 2:
-    INSTALL_REQUIRES.append("enum34")
 
 setup(
     name="ispyb",
@@ -27,16 +23,14 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    python_requires=">=3.6",
     entry_points={"libtbx.precommit": ["ispyb = ispyb"]},
     project_urls={"Documentation": "https://ispyb.readthedocs.io"},
 )


### PR DESCRIPTION
Closes #101.

This will open up the opportunity to modernise the code base, which I haven't done in this PR, but will do after it's merged.