### PR TITLE
Fix code convention issues

### DIFF
--- a/ispyb/interface/acquisition.py
+++ b/ispyb/interface/acquisition.py
@@ -8,11 +8,11 @@ import ispyb.model.datacollection
 
 class IF(DataArea):
     @abc.abstractmethod
-    def get_data_collection_group_params(cls):
+    def get_data_collection_group_params(self):
         pass
 
     @abc.abstractmethod
-    def get_data_collection_params(cls):
+    def get_data_collection_params(self):
         pass
 
     @abc.abstractmethod

--- a/ispyb/interface/core.py
+++ b/ispyb/interface/core.py
@@ -7,7 +7,7 @@ class IF(DataArea):
     """Core provides methods to store and retrieve data in the core tables."""
 
     @abc.abstractmethod
-    def get_sample_params(cls):
+    def get_sample_params(self):
         pass
 
     @abc.abstractmethod
@@ -15,46 +15,46 @@ class IF(DataArea):
         pass
 
     @abc.abstractmethod
-    def retrieve_visit_id(cls, visit):
+    def retrieve_visit_id(self, visit):
         """Get the database ID for a visit on the form mx1234-5."""
         pass
 
     @abc.abstractmethod
-    def retrieve_datacollection_id(cls, img_filename, img_fileloc):
+    def retrieve_datacollection_id(self, img_filename, img_fileloc):
         """Get the database ID for the data collection corresponding to the given diffraction image file."""
         pass
 
     @abc.abstractmethod
-    def retrieve_current_sessions(cls, beamline, tolerance_mins=0):
+    def retrieve_current_sessions(self, beamline, tolerance_mins=0):
         """Get a result-set with the currently active sessions on the given beamline."""
         pass
 
     @abc.abstractmethod
-    def retrieve_current_sessions_for_person(cls, beamline, fed_id, tolerance_mins=0):
+    def retrieve_current_sessions_for_person(self, beamline, fed_id, tolerance_mins=0):
         """Get a result-set with the currently active sessions on the given beamline."""
         pass
 
     @abc.abstractmethod
-    def retrieve_most_recent_session(cls, beamline, proposal_code):
+    def retrieve_most_recent_session(self, beamline, proposal_code):
         """Get a result-set with the most recent session on the given beamline for the given proposal code """
         pass
 
     @abc.abstractmethod
-    def retrieve_persons_for_proposal(cls, proposal_code, proposal_number):
+    def retrieve_persons_for_proposal(self, proposal_code, proposal_number):
         """Get a result-set with the persons associated with a given proposal specified by proposal code, proposal_number"""
         pass
 
     @abc.abstractmethod
-    def retrieve_current_cm_sessions(cls, beamline):
+    def retrieve_current_cm_sessions(self, beamline):
         """Get a result-set with the currently active commissioning (cm) sessions on the given beamline."""
         pass
 
     @abc.abstractmethod
-    def retrieve_active_plates(cls, beamline):
+    def retrieve_active_plates(self, beamline):
         """Get a result-set with the submitted plates not yet in local storage on a given beamline"""
         pass
 
     @abc.abstractmethod
-    def retrieve_proposal_title(cls, proposal_code, proposal_number):
+    def retrieve_proposal_title(self, proposal_code, proposal_number):
         """Get the title of a given proposal"""
         pass

--- a/ispyb/interface/screening.py
+++ b/ispyb/interface/screening.py
@@ -5,29 +5,29 @@ from ispyb.interface.dataarea import DataArea
 
 class IF(DataArea):
     @abc.abstractmethod
-    def get_screening_params(cls):
+    def get_screening_params(self):
         pass
 
     @abc.abstractmethod
-    def get_screening_input_params(cls):
+    def get_screening_input_params(self):
         pass
 
     @abc.abstractmethod
-    def get_screening_output_params(cls):
+    def get_screening_output_params(self):
         pass
 
     @abc.abstractmethod
-    def get_screening_output_lattice_params(cls):
+    def get_screening_output_lattice_params(self):
         pass
 
     @abc.abstractmethod
-    def get_screening_strategy_params(cls):
+    def get_screening_strategy_params(self):
         pass
 
     @abc.abstractmethod
-    def get_screening_strategy_wedge_params(cls):
+    def get_screening_strategy_wedge_params(self):
         pass
 
     @abc.abstractmethod
-    def get_screening_strategy_sub_wedge_params(cls):
+    def get_screening_strategy_sub_wedge_params(self):
         pass


### PR DESCRIPTION
as highlighted by LGTM.
The first parameter of a method is always called `self`.