### PR TITLE
Enable use_pure option of mysqlconnector

### DIFF
--- a/ispyb/sqlalchemy/__init__.py
+++ b/ispyb/sqlalchemy/__init__.py
@@ -60,7 +60,8 @@ def session(credentials=None):
 
     engine = sqlalchemy.create_engine(
         "mysql+mysqlconnector://{username}:{password}@{host}:{port}/{database}".format(
-            **credentials
-        )
+            **credentials,
+        ),
+        connect_args={"use_pure": True},
     )
     return sqlalchemy.orm.sessionmaker(bind=engine)()


### PR DESCRIPTION
This works around an issue reading back BINARY blobs (for *.externalID columns) that were mistakenly read back as UTF-8 strings.

See also: https://stackoverflow.com/a/53468522