### PR TITLE
Backwards compatibility for ispyb-database < 1.19.0

### DIFF
--- a/tests/sqlalchemy/test_models.py
+++ b/tests/sqlalchemy/test_models.py
@@ -1,9 +1,11 @@
 import datetime
 import pytest
 
+import ispyb.sqlalchemy
 from ispyb.sqlalchemy import (
     AutoProcProgram,
     AutoProcScaling,
+    Container,
     DataCollection,
     DataCollectionGroup,
     ProcessingJob,
@@ -122,3 +124,10 @@ def test_processing_job(alchemy, insert_processing_job):
     assert pjis.DataCollection is pj.DataCollection
     assert pjis.startImage == 1
     assert pjis.endImage == 180
+
+
+def test_container(alchemy):
+    container = alchemy.query(Container).first()
+    if ispyb.sqlalchemy.ispyb_schema_version >= "1.19.0":
+        assert container.containerTypeId is None
+        assert container.ContainerType is None


### PR DESCRIPTION
The `Container.containerTypeId` column was added in ispyb-database v1.19.0, and including that column in the ORM model breaks usage with versions prior to 1.19.0. This adds a possible mechanism for providing backwards compatibility for earlier ispyb-database versions by deferring the loading of the column if the version is < 1.19.0, so a `ProgrammingError` will only be observed if calling code explicitly attempts to access the column.