### PR TITLE
Add a debug facility to the sqlalchemy interface

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,9 @@ History
 Unreleased / master
 -------------------
 
-6.0.0 (XXXX-XX-XX)
+* ``ispyb.sqlalchemy.enable_debug_logging()`` will log every SQL call before execution through the Python logging framework
+
+6.0.0 (2021-03-05)
 ------------------
 
 * New ``ispyb.sqlalchemy`` module containing `SQLAlchemy <https://www.sqlalchemy.org>`_ ORM models to interface with ISPyB

--- a/src/ispyb/cli/last_data_collections_on.py
+++ b/src/ispyb/cli/last_data_collections_on.py
@@ -38,7 +38,13 @@ def get_last_data_collections_on(beamlines, db_session, limit=10, latest_dcid=No
     query = (
         db_session.query(BLSession, DataCollection, GridInfo, Proposal)
         .options(
-            Load(DataCollection).load_only("dataCollectionId", "numberOfImages"),
+            Load(DataCollection).load_only(
+                "dataCollectionId",
+                "fileTemplate",
+                "imageDirectory",
+                "numberOfImages",
+                "startTime",
+            ),
             Load(Proposal).load_only("proposalCode", "proposalNumber"),
             Load(BLSession).load_only("beamLineName", "visit_number"),
             Load(GridInfo).load_only("steps_x", "steps_y"),

--- a/src/ispyb/cli/last_data_collections_on.py
+++ b/src/ispyb/cli/last_data_collections_on.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import pathlib
 import sys
 import time
@@ -109,6 +110,14 @@ def main(args=None):
         metavar="N",
         help="show the last N collections for each beamline",
     )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        dest="debug",
+        default=False,
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument("--credentials", action="store", type=pathlib.Path)
     parser.add_argument(
         "--synchweb-url",
@@ -123,6 +132,13 @@ def main(args=None):
         parser.print_help()
         sys.exit(0)
     t0 = time.time()
+
+    if args.debug:
+        console = logging.StreamHandler(sys.stdout)
+        console.setLevel(logging.DEBUG)
+        logging.getLogger("ispyb").addHandler(console)
+        logging.getLogger("ispyb").setLevel(logging.DEBUG)
+        ispyb.sqlalchemy.enable_debug_logging()
 
     db_session = ispyb.sqlalchemy.session(args.credentials)
 

--- a/src/ispyb/sqlalchemy/__init__.py
+++ b/src/ispyb/sqlalchemy/__init__.py
@@ -99,7 +99,7 @@ def enable_debug_logging():
             cause = f"\n{indent}originating from {frame.f_code.co_filename}:{line}"
             break
         if parameters:
-            parameters = f"\n{indent}with {parameters=}"
+            parameters = f"\n{indent}with parameters={parameters}"
         else:
             parameters = ""
 

--- a/src/ispyb/sqlalchemy/__init__.py
+++ b/src/ispyb/sqlalchemy/__init__.py
@@ -1,12 +1,15 @@
 import configparser
 import os
+import logging
 
+import sqlalchemy.engine
 import sqlalchemy.orm
 from sqlalchemy.orm import relationship
 
 from ._auto_db_schema import *  # noqa F403; lgtm
 from ._auto_db_schema import AutoProcProgram, AutoProcScaling, ProcessingJob
 
+logger = logging.getLogger("ispyb.sqlalchemy")
 
 AutoProcProgram.AutoProcProgramAttachments = relationship("AutoProcProgramAttachment")
 AutoProcScaling.AutoProcScalingStatistics = relationship("AutoProcScalingStatistics")
@@ -65,3 +68,45 @@ def session(credentials=None):
         connect_args={"use_pure": True},
     )
     return sqlalchemy.orm.sessionmaker(bind=engine)()
+
+
+def enable_debug_logging():
+    """Write debug level logging output for every executed SQL query.
+
+    This setting will persist throughout the Python process lifetime and affect
+    all existing and future sqlalchemy sessions. This should not be used in
+    production as it can be expensive, can leak sensitive information, and,
+    once enabled, cannot be disabled.
+    """
+    if hasattr(enable_debug_logging, "enabled"):
+        return
+    enable_debug_logging.enabled = True
+
+    _sqlalchemy_root = os.path.dirname(sqlalchemy.__file__)
+
+    import traceback
+
+    @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "before_cursor_execute")
+    def log_sql_call(conn, cursor, statement, parameters, context, executemany):
+        count = getattr(log_sql_call, "_count", 0) + 1
+        setattr(log_sql_call, "_count", count)
+
+        indent = "    "
+        cause = ""
+        for frame, line in traceback.walk_stack(None):
+            if frame.f_code.co_filename.startswith(_sqlalchemy_root):
+                continue
+            cause = f"\n{indent}originating from {frame.f_code.co_filename}:{line}"
+            break
+        if parameters:
+            parameters = f"\n{indent}with {parameters=}"
+        else:
+            parameters = ""
+
+        logger.debug(
+            f"SQL query #{count}:\n"
+            + indent
+            + str(statement).replace("\n", "\n" + indent)
+            + parameters
+            + cause
+        )


### PR DESCRIPTION
When `ispyb.sqlalchemy.enable_debug_logging()` is called, all future SQL
commands executed via the sqlalchemy interface will be logged through
the Python logging framework. This should not be used in production
as it can be expensive, can leak sensitive information, and, once
enabled, cannot be disabled.

Added a `--debug` flag to the `ispyb.last_data_collections_on`
command to demonstrate.