### PR TITLE
ispyb.open(): support ISPYB_CREDENTIALS envvar

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased / master
 -------------------
 
+* ``ispyb.open()`` now supports reading the credentials file from the ISPYB_CREDENTIALS environment variable. The function's ``configuration_file`` parameter is now deprecated - positional arguments or ``credentials`` should be used instead.
+
 6.0.1 (2021-03-16)
 ------------------
 

--- a/src/ispyb/__init__.py
+++ b/src/ispyb/__init__.py
@@ -8,12 +8,26 @@ _log = logging.getLogger("ispyb")
 
 
 def open(credentials=None):
-    """Create an ISPyB connection using settings from a configuration file.
-    This can be used either as a function call or as a context manager.
+    """Create an ISPyB connection.
 
-    :param configuration_file: Full path to a file containing database
-                               credentials
-    :return: ISPyB connection object
+    Args:
+        credentials: a config file containing database credentials.
+            If `credentials=None` then look for a credentials file in the
+            "ISPYB_CREDENTIALS" environment variable.
+
+            Example credentials file::
+
+                [ispyb_mariadb_sp]
+                user = ispyb_api
+                pw = password_1234
+                host = localhost
+                port = 3306
+                db = ispybtest
+                reconn_attempts = 6
+                reconn_delay = 1
+
+    Returns:
+        The ISPyB connection object.
     """
     if not credentials:
         credentials = os.getenv("ISPYB_CREDENTIALS")

--- a/src/ispyb/__init__.py
+++ b/src/ispyb/__init__.py
@@ -1,13 +1,14 @@
 import configparser
 import logging
 import os
+import warnings
 
 __version__ = "6.0.1"
 
 _log = logging.getLogger("ispyb")
 
 
-def open(credentials=None):
+def open(credentials=None, configuration_file=None):
     """Create an ISPyB connection.
 
     Args:
@@ -29,8 +30,15 @@ def open(credentials=None):
     Returns:
         The ISPyB connection object.
     """
-    if not credentials:
-        credentials = os.getenv("ISPYB_CREDENTIALS")
+    if configuration_file:
+        warnings.warn(
+            "The parameter 'configuration_file' is deprecated and will be removed in a future version. "
+            "Use positional arguments or 'credentials' instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    credentials = credentials or configuration_file or os.getenv("ISPYB_CREDENTIALS")
 
     if not credentials:
         raise AttributeError("No credentials file specified")
@@ -38,6 +46,7 @@ def open(credentials=None):
     config = configparser.RawConfigParser(allow_no_value=True)
     if not config.read(credentials):
         raise AttributeError(f"No configuration found at {credentials}")
+
     if config.has_section("ispyb_mariadb_sp"):
         from ispyb.connector.mysqlsp.main import ISPyBMySQLSPConnector as Connector
 

--- a/src/ispyb/__init__.py
+++ b/src/ispyb/__init__.py
@@ -1,12 +1,13 @@
 import configparser
 import logging
+import os
 
 __version__ = "6.0.1"
 
 _log = logging.getLogger("ispyb")
 
 
-def open(configuration_file):
+def open(credentials=None):
     """Create an ISPyB connection using settings from a configuration file.
     This can be used either as a function call or as a context manager.
 
@@ -14,31 +15,31 @@ def open(configuration_file):
                                credentials
     :return: ISPyB connection object
     """
-    config = configparser.RawConfigParser(allow_no_value=True)
-    if not config.read(configuration_file):
-        raise AttributeError("No configuration found at %s" % configuration_file)
+    if not credentials:
+        credentials = os.getenv("ISPYB_CREDENTIALS")
 
-    conn = None
+    if not credentials:
+        raise AttributeError("No credentials file specified")
+
+    config = configparser.RawConfigParser(allow_no_value=True)
+    if not config.read(credentials):
+        raise AttributeError(f"No configuration found at {credentials}")
     if config.has_section("ispyb_mariadb_sp"):
         from ispyb.connector.mysqlsp.main import ISPyBMySQLSPConnector as Connector
 
+        _log.debug(f"Creating MariaDB Stored Procedure connection from {credentials}")
         credentials = dict(config.items("ispyb_mariadb_sp"))
-        _log.debug(
-            "Creating MariaDB Stored Procedure connection from %s", configuration_file
-        )
         conn = Connector(**credentials)
     elif config.has_section("ispyb_ws"):
         from ispyb.connector.ws.main import ISPyBWSConnector as Connector
 
+        _log.debug(f"Creating Webservices connection from {credentials}")
         credentials = dict(config.items("ispyb_ws"))
-        _log.debug("Creating Webservices connection from %s", configuration_file)
         conn = Connector(**credentials)
     else:
         raise AttributeError(
-            "No supported connection type found in %s. For an example of a valid config file, please see config.example.cfg."
-            % configuration_file
+            f"No supported connection type found in {credentials}. For an example of a valid config file, please see config.example.cfg."
         )
-
     return conn
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,0 +1,8 @@
+import ispyb
+from ispyb.connector.mysqlsp.main import ISPyBMySQLSPConnector
+
+
+def test_session_from_envvar(testconfig, monkeypatch):
+    monkeypatch.setenv("ISPYB_CREDENTIALS", testconfig)
+    conn = ispyb.open()
+    assert isinstance(conn, ISPyBMySQLSPConnector)


### PR DESCRIPTION
Optionally read credentials file from `ISPYB_CREDENTIALS` environment variable (c.f. `ispyb.sqlalchemy.session()` behaviour).