### PR TITLE
New ispyb.sqlalchemy.create_engine()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased / master
 -------------------
 
+* New ``ispyb.sqlalchemy.create_engine()`` to create an SQLAlchemy Engine using the given database credentials
+
 6.0.1 (2021-03-16)
 ------------------
 

--- a/src/ispyb/sqlalchemy/__init__.py
+++ b/src/ispyb/sqlalchemy/__init__.py
@@ -76,31 +76,9 @@ def create_engine(
 def session(credentials=None):
     """Create an SQLAlchemy session.
 
-    return sqlalchemy.orm.sessionmaker(bind=engine)()
-
     Args:
         credentials: a config file or a Python dictionary containing database
-            credentials. If `credentials=None` then look for a credentials file in the
-            "ISPYB_CREDENTIALS" environment variable.
-
-            Example credentials file::
-
-                [ispyb_sqlalchemy]
-                username = user
-                password = password
-                host = localhost
-                port = 3306
-                database = ispyb_build
-
-           Example credentials dictionary::
-
-               {
-                   "username": "user",
-                   "password": "password",
-                   "host": localhost",
-                   "port": 3306,
-                   "database": "ispyb",
-               }
+            credentials, see function `create_engine()` for details.
 
     Returns:
         The SQLAlchemy session.

--- a/tests/sqlalchemy/test_session.py
+++ b/tests/sqlalchemy/test_session.py
@@ -5,6 +5,11 @@ import sqlalchemy.orm
 import ispyb.sqlalchemy
 
 
+def test_create_engine(testconfig):
+    engine = ispyb.sqlalchemy.create_engine(testconfig)
+    assert isinstance(engine, sqlalchemy.engine.Engine)
+
+
 def test_session_from_dict(testconfig):
     config = configparser.RawConfigParser(allow_no_value=True)
     config.read(testconfig)


### PR DESCRIPTION
A wrapper around sqlalchemy.create_engine() using the given credentials.


[edited by @Anthchirp: closes alternative PR #140)