### PR TITLE
Prepare deprecation of the sqlalchemy.session() function

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased / master
 -------------------
 
+* ``ispyb.sqlalchemy.url()`` is a function that generates the SQLAlchemy connection URL from the ISPyB configuration
+
 6.0.1 (2021-03-16)
 ------------------
 

--- a/src/ispyb/cli/last_data_collections_on.py
+++ b/src/ispyb/cli/last_data_collections_on.py
@@ -4,6 +4,7 @@ import pathlib
 import sys
 import time
 
+import sqlalchemy.orm
 from sqlalchemy.orm import Load
 
 import ispyb
@@ -146,7 +147,9 @@ def main(args=None):
         logging.getLogger("ispyb").setLevel(logging.DEBUG)
         ispyb.sqlalchemy.enable_debug_logging()
 
-    db_session = ispyb.sqlalchemy.session(args.credentials)
+    url = ispyb.sqlalchemy.url(args.credentials)
+    engine = sqlalchemy.create_engine(url, connect_args={"use_pure": True})
+    db_session = sqlalchemy.orm.Session(bind=engine)
 
     latest_dcid = None
     print("------Date------ Beamline --DCID-- ---Visit---")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
 # pytest configuration file
 
-
 import os
-import ispyb.sqlalchemy
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+import ispyb.sqlalchemy
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def testconfig():
     """Return the path to a configuration file pointing to a test database."""
     config_file = os.path.abspath(
@@ -40,6 +42,26 @@ def testconfig_ws():
     return config_file
 
 
-@pytest.fixture
-def alchemy(testconfig):
-    return ispyb.sqlalchemy.session(testconfig)
+@pytest.fixture(scope="session")
+def db_engine(testconfig):
+    """Yields a SQLAlchemy engine"""
+    engine = create_engine(
+        ispyb.sqlalchemy.url(testconfig), connect_args={"use_pure": True}
+    )
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture(scope="session")
+def db_session_factory(db_engine):
+    """Returns a SQLAlchemy scoped session factory"""
+    return scoped_session(sessionmaker(bind=db_engine))
+
+
+@pytest.fixture(scope="function")
+def db_session(db_session_factory):
+    """Yields a SQLAlchemy connection which is rollbacked after the test"""
+    session_ = db_session_factory()
+    yield session_
+    session_.rollback()
+    session_.close()

--- a/tests/sqlalchemy/test_models.py
+++ b/tests/sqlalchemy/test_models.py
@@ -12,9 +12,9 @@ from ispyb.sqlalchemy import (
 )
 
 
-def test_data_collection(alchemy):
+def test_data_collection(db_session):
     query = (
-        alchemy.query(DataCollection)
+        db_session.query(DataCollection)
         .order_by(DataCollection.dataCollectionId)
         .filter_by(SESSIONID=55168)
     )
@@ -24,8 +24,8 @@ def test_data_collection(alchemy):
     assert dc.dataCollectionId == 1052494
 
 
-def test_data_collection_group(alchemy):
-    query = alchemy.query(DataCollectionGroup).filter(
+def test_data_collection_group(db_session):
+    query = db_session.query(DataCollectionGroup).filter(
         DataCollectionGroup.dataCollectionGroupId == 988855
     )
     dcg = query.one()
@@ -35,8 +35,8 @@ def test_data_collection_group(alchemy):
     assert dcg.BLSession.beamLineName == "i03"
 
 
-def test_auto_proc_scaling(alchemy):
-    query = alchemy.query(AutoProcScaling).filter(
+def test_auto_proc_scaling(db_session):
+    query = db_session.query(AutoProcScaling).filter(
         AutoProcScaling.autoProcScalingId == 596133
     )
     aps = query.one()
@@ -56,8 +56,8 @@ def test_auto_proc_scaling(alchemy):
     assert ap.refinedCell_a == 92.5546
 
 
-def test_auto_proc_program(alchemy):
-    query = alchemy.query(AutoProcProgram).filter(
+def test_auto_proc_program(db_session):
+    query = db_session.query(AutoProcProgram).filter(
         AutoProcProgram.autoProcProgramId == 56425592
     )
     app = query.one()
@@ -73,7 +73,7 @@ def test_auto_proc_program(alchemy):
 
 
 @pytest.fixture
-def insert_processing_job(alchemy):
+def insert_processing_job(db_session):
     # Add some ProcessingJob* entries
     pj = ProcessingJob(
         dataCollectionId=993677,
@@ -91,15 +91,17 @@ def insert_processing_job(alchemy):
         startImage=1,
         endImage=180,
     )
-    alchemy.add_all([pj, pjp, pjis])
-    alchemy.commit()
+    db_session.add_all([pj, pjp, pjis])
+    db_session.commit()
     return pj.processingJobId
 
 
-def test_processing_job(alchemy, insert_processing_job):
+def test_processing_job(db_session, insert_processing_job):
     pj_id = insert_processing_job
 
-    query = alchemy.query(ProcessingJob).filter(ProcessingJob.processingJobId == pj_id)
+    query = db_session.query(ProcessingJob).filter(
+        ProcessingJob.processingJobId == pj_id
+    )
     assert query.count() == 1
     pj = query.first()
     assert pj.processingJobId == pj_id

--- a/tests/sqlalchemy/test_session.py
+++ b/tests/sqlalchemy/test_session.py
@@ -18,3 +18,20 @@ def test_session_from_envvar(testconfig, monkeypatch):
     monkeypatch.setenv("ISPYB_CREDENTIALS", testconfig)
     session = ispyb.sqlalchemy.session()
     assert isinstance(session, sqlalchemy.orm.session.Session)
+
+
+def test_url_from_dict(testconfig):
+    config = configparser.RawConfigParser(allow_no_value=True)
+    config.read(testconfig)
+    url = ispyb.sqlalchemy.url(credentials=dict(config.items("ispyb_sqlalchemy")))
+    assert url.startswith("mysql+mysqlconnector")
+    # check we can create a valid engine with this url
+    sqlalchemy.create_engine(url, connect_args={"use_pure": True})
+
+
+def test_url_from_envar(testconfig, monkeypatch):
+    monkeypatch.setenv("ISPYB_CREDENTIALS", testconfig)
+    url = ispyb.sqlalchemy.url()
+    assert url.startswith("mysql+mysqlconnector")
+    # check we can create a valid engine with this url
+    sqlalchemy.create_engine(url, connect_args={"use_pure": True})

--- a/tests/sqlalchemy/test_session.py
+++ b/tests/sqlalchemy/test_session.py
@@ -1,4 +1,5 @@
 import configparser
+import pytest
 
 import sqlalchemy.orm
 
@@ -8,15 +9,17 @@ import ispyb.sqlalchemy
 def test_session_from_dict(testconfig):
     config = configparser.RawConfigParser(allow_no_value=True)
     config.read(testconfig)
-    session = ispyb.sqlalchemy.session(
-        credentials=dict(config.items("ispyb_sqlalchemy"))
-    )
+    with pytest.warns(PendingDeprecationWarning):
+        session = ispyb.sqlalchemy.session(
+            credentials=dict(config.items("ispyb_sqlalchemy"))
+        )
     assert isinstance(session, sqlalchemy.orm.session.Session)
 
 
 def test_session_from_envvar(testconfig, monkeypatch):
     monkeypatch.setenv("ISPYB_CREDENTIALS", testconfig)
-    session = ispyb.sqlalchemy.session()
+    with pytest.warns(PendingDeprecationWarning):
+        session = ispyb.sqlalchemy.session()
     assert isinstance(session, sqlalchemy.orm.session.Session)
 
 


### PR DESCRIPTION
Alternative to #139. Instead of providing our own `create_engine()` function just tell the user to use the official `sqlalchemy.create_engine` function. The only added value really comes in the form of the credential parsing, and that can be done via a `url()` function which reads out the ISPyB configuration and turns it into an SQLAlchemy-compatible connection string.

With this PR the documentation should then basically tell the user to 
```python
import sqlalchemy.engine
import sqlalchemy.orm
sessionator = sqlalchemy.orm.sessionmaker(bind=
       sqlalchemy.engine(ispyb.sqlalchemy.url(), connect_args={"use_pure":True})
    )

with sessionator() as session:
   ... # do a thing

with sessionator() as session:
   ... # do another thing
```

(closes #139)