### PR TITLE
last_data_collections_on: new session for each query

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 Unreleased / master
 -------------------
+* Fix bug preventing ``ispyb.last_data_collections_on`` from seeing new data collections in ``--follow`` mode
 
 6.1.1 (2021-04-13)
 ------------------

--- a/src/ispyb/cli/last_data_collections_on.py
+++ b/src/ispyb/cli/last_data_collections_on.py
@@ -149,15 +149,16 @@ def main(args=None):
 
     url = ispyb.sqlalchemy.url(args.credentials)
     engine = sqlalchemy.create_engine(url, connect_args={"use_pure": True})
-    db_session = sqlalchemy.orm.Session(bind=engine)
+    Session = sqlalchemy.orm.sessionmaker(bind=engine)
 
     latest_dcid = None
     print("------Date------ Beamline --DCID-- ---Visit---")
     # Terminate after 24 hours
     while time.time() - t0 < 60 * 60 * 24:
-        rows = get_last_data_collections_on(
-            args.beamline, db_session, limit=args.limit, latest_dcid=latest_dcid
-        )
+        with Session() as db_session:
+            rows = get_last_data_collections_on(
+                args.beamline, db_session, limit=args.limit, latest_dcid=latest_dcid
+            )
         if rows:
             # Record the last observed dcid per beamline
             latest_dcid = rows[0].DataCollection.dataCollectionId


### PR DESCRIPTION
Otherwise transaction isolation level likely means that we won't see any new data collections added after the command was started (which defeats the point of the '-f' option).