### PR TITLE
Ensure ispyb.job test uses correct credentials

### DIFF
--- a/tests/cli/test_job.py
+++ b/tests/cli/test_job.py
@@ -22,7 +22,8 @@ def test_creation_failure(capsys):
     assert "must specify at least" in e.value.code
 
 
-def test_basic(capsys, testconfig):
+def test_basic(capsys, testconfig, monkeypatch):
+    monkeypatch.setenv("ISPYB_CREDENTIALS", testconfig)
     job.main(["5"])
     captured = capsys.readouterr()
     assert not captured.err
@@ -34,7 +35,8 @@ def test_basic(capsys, testconfig):
     assert "Sweeps:" not in captured.out
 
 
-def test_verbose(capsys, testconfig):
+def test_verbose(capsys, testconfig, monkeypatch):
+    monkeypatch.setenv("ISPYB_CREDENTIALS", testconfig)
     job.main(["5", "-v"])
     captured = capsys.readouterr()
     assert not captured.err


### PR DESCRIPTION
It the tests are run in an environment that has separately defined the `ISPYB_CREDENTIALS` environment variable, then this test would previously pick up those credentials instead of `testconfig` as intended.