### PR TITLE
If no sweeps are specified or inferred when creating a new processing job then continue without any rather than exiting

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 Unreleased / master
 -------------------
 * Add insert methods for new cryo-EM tables. `#150 <https://github.com/DiamondLightSource/ispyb-api/pull/150>`_
+* Change ``ispyb.job`` so that new processing jobs can be created without specifying any sweeps. Useful for EM data collections.
 
 6.2.0 (2021-04-19)
 ------------------

--- a/src/ispyb/cli/job.py
+++ b/src/ispyb/cli/job.py
@@ -63,10 +63,12 @@ def create_processing_job(i, options):
         start = dc_info.image_start_number
         number = dc_info.image_count
         if not start or not number:
-            sys.exit("Can not automatically infer data collection sweep for this DCID")
-        end = start + number - 1
-        sweeps = [(dcid, start, end)]
-        print(f"Using images {start} to {end} for data collection sweep")
+            print("Can not automatically infer data collection sweep for this DCID")
+            sweeps = []
+        else:
+            end = start + number - 1
+            sweeps = [(dcid, start, end)]
+            print(f"Using images {start} to {end} for data collection sweep")
 
     parameters = []
     for p in options.parameters:

--- a/src/ispyb/cli/job.py
+++ b/src/ispyb/cli/job.py
@@ -237,7 +237,6 @@ def main(cmd_args=sys.argv[1:]):
         default=[],
         metavar="DCID:START:END",
         help="add an image range from a sweep of any data collection ID to the processing job. "
-        "Each job must have at least one sweep. "
         "If no sweep is defined all images from the primary data collection ID are used",
     )
     if zocalo:

--- a/src/ispyb/cli/job.py
+++ b/src/ispyb/cli/job.py
@@ -237,7 +237,7 @@ def main(cmd_args=sys.argv[1:]):
         default=[],
         metavar="DCID:START:END",
         help="add an image range from a sweep of any data collection ID to the processing job. "
-        "If no sweep is defined all images from the primary data collection ID are used",
+        "If no sweep is defined all images from the primary data collection ID are used if the data collection ID can be inferred",
     )
     if zocalo:
         group.add_option(


### PR DESCRIPTION
When using `ispyb.job --new` to create a processing job if no sweeps are specified then an attempt is made to infer one from information in the `DataCollection` table. For the EM test data collection this necessary information is not given. This leads to an exit before anything is inserted in the DB. For this case it is desirable to not insert in the `ProcessingJobImageSweep` table if no sweeps are specified and none can be inferred, but to still create a processing job.