### PR TITLE
Add ability to store values for the new column AutoProcScalingStatistics.resIOverSigI2

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  DATABASE_SCHEMA: 1.23.1
+  DATABASE_SCHEMA: 1.24.0
 
 trigger:
   branches:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Unreleased / master
 -------------------
 
 * Update SQLAlchemy ORM models for ispyb-database v1.25.0
+* Support XML file with multiple ``AutoProcScalingContainers`` `#155 <https://github.com/DiamondLightSource/ispyb-api/pull/155>`_
+* Add ability to store values for the new column ``AutoProcScalingStatistics.resIOverSigI2`` `#157 <https://github.com/DiamondLightSource/ispyb-api/pull/157>`_
 
 6.5.0 (2021-07-08)
 ------------------

--- a/src/ispyb/sp/mxprocessing.py
+++ b/src/ispyb/sp/mxprocessing.py
@@ -57,6 +57,7 @@ class MXProcessing(ispyb.interface.processing.IF):
             ("n_tot_obs", None),
             ("n_tot_unique_obs", None),
             ("mean_i_sig_i", None),
+            ("res_i_sig_i_2", None),
             ("completeness", None),
             ("multiplicity", None),
             ("anom", "0"),
@@ -301,7 +302,7 @@ class MXProcessing(ispyb.interface.processing.IF):
         id = None
         values = [id, parent_id] + values1 + values2 + values3
         return self.get_connection().call_sp_write(
-            procname="insert_processing_scaling", args=values
+            procname="insert_processing_scaling_v2", args=values
         )
 
     def upsert_integration(self, values):

--- a/tests/test_mxprocessing.py
+++ b/tests/test_mxprocessing.py
@@ -257,7 +257,11 @@ def test_processing2(testdb):
     id = mxprocessing.insert_scaling(
         parentid, list(params1.values()), list(params2.values()), list(params3.values())
     )
-
+    assert id is not None
+    params3["res_i_sig_i_2"] = 1.5
+    id = mxprocessing.insert_scaling(
+        parentid, list(params1.values()), list(params2.values()), list(params3.values())
+    )
     assert id is not None
 
     params = mxprocessing.get_quality_indicators_params()


### PR DESCRIPTION
* Add the new key `res_i_sig_i_2` to the `_scaling_params` StrictOrderedDict.
* Use the new sproc `insert_processing_scaling_v2`.