### PR TITLE
Precommit updates

### DIFF
--- a/.azure-pipelines/flake8-validation.py
+++ b/.azure-pipelines/flake8-validation.py
@@ -8,8 +8,6 @@ try:
         [
             "flake8",
             "--exit-zero",
-            "--max-line-length=88",
-            "--select=E401,E711,E712,E713,E714,E721,E722,E901,F401,F402,F403,F405,F631,F632,F633,F811,F812,F821,F822,F841,F901,W191,W291,W292,W293,W602,W603,W604,W605,W606",
         ],
         capture_output=True,
         check=True,

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 6.9.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = (version="{current_version}")
+replace = (version="{new_version}")
+
+[bumpversion:file:src/ispyb/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,30 @@
 repos:
 
 # Automatically sort imports
-- repo: https://github.com/PyCQA/isort.git
-  rev: 5.6.4
+- repo: https://github.com/PyCQA/isort
+  rev: 5.9.3
   hooks:
   - id: isort
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 21.6b0
   hooks:
   - id: black
     args: [--safe, --quiet]
 
-# Syntax check and flake8 checks
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.0.0
+# Linting
+- repo: https://github.com/PyCQA/flake8
+  rev: 3.9.2
   hooks:
+  - id: flake8
+    additional_dependencies: ['flake8-comprehensions==3.5.0']
+
+# Syntax validation and some basic sanity checks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+  - id: check-merge-conflict
   - id: check-ast
   - id: check-yaml
-  - id: flake8
-    args: ['--max-line-length=88', '--select=E401,E711,E712,E713,E714,E721,E722,E901,F401,F402,F403,F405,F631,F632,F633,F811,F812,F821,F822,F841,F901,W191,W291,W292,W293,W602,W603,W604,W605,W606']
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[bumpversion]
-current_version = 6.9.0
-commit = True
-tag = True
-
 [metadata]
 name = ispyb
 description = Python package to access ISPyB database
@@ -11,7 +6,7 @@ long_description = This package provides a Python interface to ISPyB. It can acc
 author = Diamond Light Source
 author_email = scientificsoftware@diamond.ac.uk
 license = Apache License, Version 2.0
-classifiers = 
+classifiers =
 	Development Status :: 5 - Production/Stable
 	License :: OSI Approved :: Apache Software License
 	Programming Language :: Python :: 3
@@ -21,25 +16,25 @@ classifiers =
 	Programming Language :: Python :: 3.9
 	Operating System :: OS Independent
 	Topic :: Software Development :: Libraries :: Python Modules
-keywords = 
+keywords =
 	ISPyB
 	database
-project-urls = 
+project-urls =
 	Documentation = https://ispyb.readthedocs.io
 	GitHub = https://github.com/DiamondLightSource/ispyb-api
 	Bug-Tracker = https://github.com/DiamondLightSource/ispyb-api/issues
 
 [options]
 include_package_data = True
-install_requires = 
+install_requires =
 	mysql-connector-python
 	sqlalchemy
 	tabulate
 packages = find:
-package_dir = 
+package_dir =
 	=src
 python_requires = >=3.6
-scripts = 
+scripts =
 	bin/dimple2ispyb.py
 	bin/mxdatareduction2ispyb.py
 
@@ -56,10 +51,19 @@ libtbx.precommit =
 [options.packages.find]
 where = src
 
-[bumpversion:file:setup.py]
-search = (version="{current_version}")
-replace = (version="{new_version}")
+[flake8]
+# Black disagrees with flake8 on a few points. Ignore those.
+ignore = E203, E266, E501, W503
+# E203 whitespace before ':'
+# E266 too many leading '#' for block comment
+# E501 line too long
+# W503 line break before binary operator
 
-[bumpversion:file:src/ispyb/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"
+max-line-length = 88
+
+select =
+    E401,E711,E712,E713,E714,E721,E722,E901,
+    F401,F402,F403,F405,F541,F631,F632,F633,F811,F812,F821,F822,F841,F901,
+    W191,W291,W292,W293,W602,W603,W604,W605,W606,
+    # flake8-comprehensions, https://github.com/adamchainz/flake8-comprehensions
+    C4,

--- a/src/ispyb/interface/core.py
+++ b/src/ispyb/interface/core.py
@@ -36,7 +36,7 @@ class IF(DataArea):
 
     @abc.abstractmethod
     def retrieve_most_recent_session(self, beamline, proposal_code):
-        """Get a result-set with the most recent session on the given beamline for the given proposal code """
+        """Get a result-set with the most recent session on the given beamline for the given proposal code"""
         pass
 
     @abc.abstractmethod

--- a/src/ispyb/sp/core.py
+++ b/src/ispyb/sp/core.py
@@ -199,7 +199,7 @@ class Core(ispyb.interface.core.IF):
         )
 
     def retrieve_most_recent_session(self, beamline, proposal_code):
-        """Get a result-set with the most recent session on the given beamline for the given proposal code """
+        """Get a result-set with the most recent session on the given beamline for the given proposal code"""
         return self.get_connection().call_sp_retrieve(
             procname="retrieve_most_recent_session", args=(beamline, proposal_code)
         )


### PR DESCRIPTION
Newer versions of isort, black, flake8; enable a few more flake8 checks.
This brings the static checks on this repository to the level of eg. zocalo/DIALS/etc.