### PR TITLE
183: Pin mysql connector version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project-urls =
 [options]
 include_package_data = True
 install_requires =
-	mysql-connector-python
+	mysql-connector-python<=8.0.29 #See https://github.com/DiamondLightSource/ispyb-api/issues/183
 	sqlalchemy
 	tabulate
 packages = find:


### PR DESCRIPTION
Fixes #183 

To test:
* Run `pip install git+https://github.com/DominicOram/ispyb-api.git@183_pin_mysql_connector`
* Run `pip list` and confirm version `8.0.29` of `mysql-connector-python` is installed