### PR TITLE
ispyb.job bug fix: sweep may start counting at 0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 Unreleased / master
 -------------------
+* ``ispyb.job``: bug fix - sweeps may start counting at 0
 
 6.12.1 (2022-10-05)
 -------------------

--- a/src/ispyb/cli/job.py
+++ b/src/ispyb/cli/job.py
@@ -41,7 +41,7 @@ def create_processing_job(i, options):
         if not match:
             sys.exit("Invalid sweep specification: " + s)
         values = tuple(map(int, match.groups()))
-        if not all(value > 0 for value in values) or values[2] < values[1]:
+        if not all(value >= 0 for value in values) or values[2] < values[1]:
             sys.exit("Invalid sweep specification: " + s)
         sweeps.append(values)
 


### PR DESCRIPTION
E.g. fixed target data collections on i24