### PR TITLE
Add support/CI for Python 3.11

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -106,6 +106,8 @@ stages:
           PYTHON_VERSION: 3.9
         python310:
           PYTHON_VERSION: 3.10
+        python311:
+          PYTHON_VERSION: 3.11
     services:
       db: mariadb
     steps:
@@ -142,7 +144,7 @@ stages:
       - task: UsePythonVersion@0
         displayName: Set up python
         inputs:
-          versionSpec: 3.9
+          versionSpec: 3.11
 
       - task: DownloadBuildArtifacts@0
         displayName: Get pre-built package

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -96,8 +96,6 @@ stages:
       vmImage: ubuntu-20.04
     strategy:
       matrix:
-        python36:
-          PYTHON_VERSION: 3.6
         python37:
           PYTHON_VERSION: 3.7
         python38:

--- a/.azure-pipelines/update-orm.yml
+++ b/.azure-pipelines/update-orm.yml
@@ -1,8 +1,8 @@
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: 3.11
-  displayName: Use Python 3.11
+    versionSpec: 3.10
+  displayName: Use Python 3.10
 
 - script: |
     set -eu

--- a/.azure-pipelines/update-orm.yml
+++ b/.azure-pipelines/update-orm.yml
@@ -1,8 +1,8 @@
 steps:
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: 3.9
-  displayName: Use Python 3.9
+    versionSpec: 3.11
+  displayName: Use Python 3.11
 
 - script: |
     set -eu

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 Unreleased / master
 -------------------
+* ``ispyb.job``: bug fix - sweeps may start counting at 0
+* Added support for Python 3.11
 
 6.12.1 (2022-10-05)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Unreleased / master
 -------------------
 * ``ispyb.job``: bug fix - sweeps may start counting at 0
 * Added support for Python 3.11
+* Remove support for Python 3.6 (end-of-life on 2021-12-23)
 
 6.12.1 (2022-10-05)
 -------------------

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ as webservices.
 Please see https://ispyb.readthedocs.io.
 
 ### Requirements
-* Python 3.6, 3.7, 3.8, 3.9, 3.10
+* Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
 * The MySQL Connector/Python package.
 * MariaDB 10.0+ or MySQL 5.6+, but we recommend MariaDB 10.2 or later.
 * An ISPyB database installed on the above. See the [ispyb-database](https://github.com/DiamondLightSource/ispyb-database) repository for details.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ as webservices.
 Please see https://ispyb.readthedocs.io.
 
 ### Requirements
-* Python 3.6, 3.7, 3.8, 3.9, 3.10, 3.11
+* Python 3.7, 3.8, 3.9, 3.10, 3.11
 * The MySQL Connector/Python package.
 * MariaDB 10.0+ or MySQL 5.6+, but we recommend MariaDB 10.2 or later.
 * An ISPyB database installed on the above. See the [ispyb-database](https://github.com/DiamondLightSource/ispyb-database) repository for details.

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
 	Development Status :: 5 - Production/Stable
 	License :: OSI Approved :: Apache Software License
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
@@ -36,7 +35,7 @@ install_requires =
 packages = find:
 package_dir =
 	=src
-python_requires = >=3.6
+python_requires = >=3.7
 scripts =
 	bin/dimple2ispyb.py
 	bin/mxdatareduction2ispyb.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
 	Operating System :: OS Independent
 	Topic :: Software Development :: Libraries :: Python Modules
 keywords =


### PR DESCRIPTION
Remove Python 3.6 support: it was [end-of-life on 2021-12-23](https://devguide.python.org/versions/#unsupported-versions)

Closes #170 