### PR TITLE
New method update_dc_append_comments

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  DATABASE_SCHEMA: 1.34.0
+  DATABASE_SCHEMA: 1.34.1
 
 trigger:
   branches:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,9 +6,6 @@ Unreleased / main
 -------------------
 
 * New method ``update_dc_append_comments`` available in the ``Acquisition`` and ``MXAcquisition`` classes
-
-7.1.0 (2023-01-18)
--------------------
 * Update SQLAlchemy ORM models for ispyb-database v1.34.0
 
 7.0.0 (2023-01-16)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,9 @@ History
 Unreleased / main
 -------------------
 
+* New method ``update_dc_append_comments`` available in the ``Acquisition`` and ``MXAcquisition`` classes
+* Update SQLAlchemy ORM models for ispyb-database v1.34.1
+
 7.1.0 (2023-01-18)
 -------------------
 * Update SQLAlchemy ORM models for ispyb-database v1.34.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,6 @@ Unreleased / main
 -------------------
 
 * New method ``update_dc_append_comments`` available in the ``Acquisition`` and ``MXAcquisition`` classes
-* Update SQLAlchemy ORM models for ispyb-database v1.34.1
 
 7.1.0 (2023-01-18)
 -------------------

--- a/src/ispyb/sp/acquisition.py
+++ b/src/ispyb/sp/acquisition.py
@@ -165,6 +165,19 @@ class Acquisition(ispyb.interface.acquisition.IF):
         """Insert or update data collection."""
         return self.get_connection().call_sp_write("upsert_dc", values)
 
+    def update_data_collection_append_comments(self, dc_id, comments, separator):
+        """Store new or update existing automatic score for a sample image.
+
+        :param dc_id: The dataCollectionId
+        :param comments: The comments to be appended
+        :param separator: A string (max 5 chars) used to separate appended from existing comment, if any.
+        :return: Nothing.
+        """
+        self.get_connection().call_sp_write(
+            procname="update_dc_append_comments",
+            args=[dc_id, comments, separator],
+        )
+
     def upsert_data_collection_file_attachment(self, values):
         """Insert or update a data collection file attachment."""
         return self.get_connection().call_sp_write("upsert_dc_file_attachment", values)

--- a/src/ispyb/sp/mxacquisition.py
+++ b/src/ispyb/sp/mxacquisition.py
@@ -21,6 +21,9 @@ class MXAcquisition(Acquisition):
         self.insert_data_collection = super().upsert_data_collection
         self.update_data_collection_group = super().upsert_data_collection_group
         self.update_data_collection = super().upsert_data_collection
+        self.update_data_collection_append_comments = (
+            super().update_data_collection_append_comments
+        )
 
     _image_params = StrictOrderedDict(
         [

--- a/tests/test_mxacquisition.py
+++ b/tests/test_mxacquisition.py
@@ -62,6 +62,9 @@ def test_mxacquisition_methods(testdb):
     assert id2 > 0
     assert id1 == id2
 
+    mxacquisition.update_data_collection_append_comments(id2, "hello", " ")
+    mxacquisition.update_data_collection_append_comments(id2, "hello", " ")
+
     rs = mxacquisition.retrieve_data_collection_main(id1)
     assert rs[0]["groupId"] == dcgid
 
@@ -79,6 +82,7 @@ def test_mxacquisition_methods(testdb):
     assert rs[0]["status"] == params["run_status"]
     assert rs[0]["noImages"] == params["n_images"]
     assert rs[0]["imgContainerSubPath"] == params["img_container_sub_path"]
+    assert rs[0]["comments"] == "hello hello"
 
     params = mxacquisition.get_image_params()
     params["parentid"] = id1


### PR DESCRIPTION
* New method `update_dc_append_comments` available in the `Acquisition` and `MXAcquisition` classes
* Use new ispyb-database version 1.34.1 (where the `ispyb_processing` role has the grant to exec the new sproc)