### PR TITLE
Require mysql-connector-python>=8.0.32

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 Unreleased / main
 -------------------
+* Require ``mysql-connector-python>=8.0.32``
 
 8.0.0 (2023-05-15)
 -------------------

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-mysql-connector-python<=8.0.29
+mysql-connector-python<=8.0.30
 pytest
 pytest-cov
 sqlalchemy

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-mysql-connector-python<=8.0.30
+mysql-connector-python>=8.0.32
 pytest
 pytest-cov
 sqlalchemy

--- a/requirements_orm.txt
+++ b/requirements_orm.txt
@@ -1,3 +1,3 @@
-mysql-connector-python<=8.0.30
+mysql-connector-python>=8.0.32
 sqlacodegen<3
 sqlalchemy<2

--- a/requirements_orm.txt
+++ b/requirements_orm.txt
@@ -1,3 +1,3 @@
-mysql-connector-python<=8.0.29
+mysql-connector-python<=8.0.30
 sqlacodegen<3
 sqlalchemy<2

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project-urls =
 [options]
 include_package_data = True
 install_requires =
-	mysql-connector-python<=8.0.30 #See https://github.com/DiamondLightSource/ispyb-api/issues/183
+	mysql-connector-python>=8.0.32
 	sqlalchemy<2
 	tabulate
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project-urls =
 [options]
 include_package_data = True
 install_requires =
-	mysql-connector-python<=8.0.29 #See https://github.com/DiamondLightSource/ispyb-api/issues/183
+	mysql-connector-python<=8.0.30 #See https://github.com/DiamondLightSource/ispyb-api/issues/183
 	sqlalchemy<2
 	tabulate
 packages = find:


### PR DESCRIPTION
The [mysql-connector-python v8.0.32 changelog](https://github.com/mysql/mysql-connector-python/blob/3fe87a163de1c1dfcf1de60bbabecc30394c3ef6/CHANGES.txt#L39) appears to suggest that the issue with v8.0.30 reported in #183 has been fixed.

Fixes #202 