### PR TITLE
(DiamondLightSource/hyperion#888) Rename pixelsPerMicron to micronsPerPixel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  DATABASE_SCHEMA: 2.0.0
+  DATABASE_SCHEMA: 3.0.0
 
 trigger:
   branches:
@@ -12,7 +12,7 @@ trigger:
 resources:
   containers:
   - container: mariadb
-    image: mariadb:10.5
+    image: mariadb:10.6
     env:
       MYSQL_DATABASE: ispybtest
       MYSQL_ROOT_PASSWORD: mysql_root_pwd

--- a/tests/test_mxacquisition.py
+++ b/tests/test_mxacquisition.py
@@ -105,8 +105,8 @@ def test_mxacquisition_methods(testdb):
     params["steps_x"] = 20
     params["steps_y"] = 31
     params["mesh_angle"] = 45.5
-    params["pixelsPerMicronX"] = 11
-    params["pixelsPerMicronY"] = 11
+    params["micronsPerPixelX"] = 11
+    params["micronsPerPixelY"] = 11
     params["snapshotOffsetXPixel"] = 2
     params["snapshotOffsetYPixel"] = 3
     params["orientation"] = "horizontal"
@@ -122,8 +122,8 @@ def test_mxacquisition_methods(testdb):
     assert gridinfo["dy_mm"] == params["dy_in_mm"]
     assert gridinfo["meshAngle"] == params["mesh_angle"]
     assert gridinfo["orientation"] == params["orientation"]
-    assert gridinfo["pixelsPerMicronX"] == params["pixelsPerMicronX"]
-    assert gridinfo["pixelsPerMicronY"] == params["pixelsPerMicronY"]
+    assert gridinfo["micronsPerPixelX"] == params["micronsPerPixelX"]
+    assert gridinfo["micronsPerPixelY"] == params["micronsPerPixelY"]
     assert gridinfo["snaked"] == 0
     assert gridinfo["snapshot_offsetXPixel"] == params["snapshotOffsetXPixel"]
     assert gridinfo["snapshot_offsetYPixel"] == params["snapshotOffsetYPixel"]
@@ -140,8 +140,8 @@ def test_mxacquisition_methods(testdb):
     params["steps_x"] = 20
     params["steps_y"] = 31
     params["mesh_angle"] = 45.5
-    params["pixelsPerMicronX"] = 11
-    params["pixelsPerMicronY"] = 11
+    params["micronsPerPixelX"] = 11
+    params["micronsPerPixelY"] = 11
     params["snapshotOffsetXPixel"] = 2
     params["snapshotOffsetYPixel"] = 3
     params["orientation"] = "horizontal"
@@ -157,8 +157,8 @@ def test_mxacquisition_methods(testdb):
     assert gridinfo["dy_mm"] == params["dy_in_mm"]
     assert gridinfo["meshAngle"] == params["mesh_angle"]
     assert gridinfo["orientation"] == params["orientation"]
-    assert gridinfo["pixelsPerMicronX"] == params["pixelsPerMicronX"]
-    assert gridinfo["pixelsPerMicronY"] == params["pixelsPerMicronY"]
+    assert gridinfo["micronsPerPixelX"] == params["micronsPerPixelX"]
+    assert gridinfo["micronsPerPixelY"] == params["micronsPerPixelY"]
     assert gridinfo["snaked"] == 0
     assert gridinfo["snapshot_offsetXPixel"] == params["snapshotOffsetXPixel"]
     assert gridinfo["snapshot_offsetYPixel"] == params["snapshotOffsetYPixel"]


### PR DESCRIPTION
This implements a change to ispyb-api to replace pixelsPerMicron with micronsPerPixel  to the dc_grid_params and dcg_grid_params, which is necessary for DiamondLightSource/hyperion#888 which is also following on from https://jira.diamond.ac.uk/browse/LIMS-564 that describes the initial mix-up

