### PR TITLE
Use DATABASE_SCHEMA version 4.10.0

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -123,8 +123,6 @@ stages:
     services:
       db: mariadb
     steps:
-    - bash:
-        sudo apt-get install mariadb-client
     - template: update-orm.yml
 
 - stage: deploy

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -1,5 +1,5 @@
 variables:
-  DATABASE_SCHEMA: 4.0.1
+  DATABASE_SCHEMA: 4.1.0
 
 trigger:
   branches:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -60,7 +60,6 @@ stages:
       - bash: |
           pip install -U pip
           pip install collective.checkdocs wheel
-          sudo apt-get install mariadb-client
         displayName: Install dependencies
 
       - bash: |
@@ -124,6 +123,8 @@ stages:
     services:
       db: mariadb
     steps:
+    - bash:
+        sudo apt-get install mariadb-client
     - template: update-orm.yml
 
 - stage: deploy

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -60,6 +60,7 @@ stages:
       - bash: |
           pip install -U pip
           pip install collective.checkdocs wheel
+          apt install mariadb-client
         displayName: Install dependencies
 
       - bash: |

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -60,7 +60,7 @@ stages:
       - bash: |
           pip install -U pip
           pip install collective.checkdocs wheel
-          apt install mariadb-client
+          sudo apt-get install mariadb-client
         displayName: Install dependencies
 
       - bash: |

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -26,7 +26,7 @@ stages:
   - job: checks
     displayName: static code analysis
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     steps:
       # Use Python >=3.7 for syntax validation
       - task: UsePythonVersion@0
@@ -50,7 +50,7 @@ stages:
   - job: build
     displayName: build package
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     steps:
       - task: UsePythonVersion@0
         displayName: Set up python
@@ -93,7 +93,7 @@ stages:
   jobs:
   - job: linux
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     strategy:
       matrix:
         python37:
@@ -119,7 +119,7 @@ stages:
   - job: update_ORM
     displayName: Update ORM
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     services:
       db: mariadb
     steps:
@@ -135,7 +135,7 @@ stages:
   - job: pypi
     displayName: Publish pypi release
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     steps:
       - checkout: none
 

--- a/.azure-pipelines/update-orm.yml
+++ b/.azure-pipelines/update-orm.yml
@@ -46,6 +46,9 @@ steps:
     database=ispybtest
     EOF
 
+    echo "Installing mariadb-client"
+    sudo apt-get install mariadb-client
+
     mkdir schema
     cd schema
     tar xfz "$(System.ArtifactsDirectory)/package/ispyb-database.tar.gz"


### PR DESCRIPTION
- Use `DATABASE_SCHEMA` 4.10.0 in the CI
- Use ubuntu-22.04 rather than ubuntu-20.04 because that's the latest and greatest
- Install `mariadb-client` because the `build.sh` script from ispyb-database is now using this