### PR TITLE
Download the ispyb-database package into a new folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Run tests
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   test:
@@ -90,7 +93,12 @@ jobs:
           export ISPYB_CREDENTIALS="./conf/config.cfg"
           PYTHONDEVMODE=1 pytest tests -ra --cov=ispyb --cov-report=xml --cov-branch
 
-      - name: Publish coverage stats
-        run: bash <(curl -s https://codecov.io/bash) -n "Python ${{ matrix.python-version }}"
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          name: ${{ matrix.python-version }}
+          files: coverage.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
         timeout-minutes: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,6 @@ jobs:
           python -m pip install -r ./requirements_dev.txt
           python -m pip install .
 
-      - name: Get pre-built package
-        uses: actions/download-artifact@v4
-        with:
-          name: package-distributions
-          path: dist/
-
       - name: Get database
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
           name: package-distributions
           path: dist/
 
+      - name: Get database
+        uses: actions/download-artifact@v4
+        with:
+          name: database
+          path: database/
+
       - uses: shogo82148/actions-setup-mysql@v1
         with:
           distribution: 'mariadb'
@@ -58,7 +64,7 @@ jobs:
       
           cp "./conf/config.example.cfg" "./conf/config.cfg"
           cp "./conf/ws_config.example.cfg" "./conf/ws_config.cfg"
-          tar xfz "dist/ispyb-database.tar.gz"
+          tar xfz "database/ispyb-database.tar.gz"
           
           printf 'Waiting for MySQL database to accept connections'
           until mariadb --defaults-file=.my.cnf -e "SHOW DATABASES" >/dev/null; do printf '.'; sleep 10; done

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -65,6 +65,8 @@ jobs:
     needs:
       - build
       - static
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   get-env-vars:
     name: Get environment variables

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -58,8 +58,6 @@ jobs:
         with:
           name: database
           path: database/
-      - name: Check package description
-        run: python setup.py checkdocs
 
   tests:
     name: Call ci unit tests workflow

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -36,10 +36,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
-      - name: Install dependencies
-        run: |
-          pip install -U pip
-          pip install  collective.checkdocs wheel
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
       - name: Build python package
         run: python3 -m build
       - name: Download ISPyB DB schema v${{ env.DATABASE_SCHEMA }} for tests

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -41,21 +41,19 @@ jobs:
           pip install -U pip
           pip install  collective.checkdocs wheel
       - name: Build python package
-        run: |
-          set -ex
-          python setup.py sdist bdist_wheel
-          mkdir -p dist/pypi
-          shopt -s extglob
-          mv -v dist/!(pypi) dist/pypi
-          git archive HEAD | gzip > dist/repo-source.tar.gz
-          ls -laR dist
+        run: python3 -m build
       - name: Download ISPyB DB schema v${{ env.DATABASE_SCHEMA }} for tests
-        run: wget -t 3 --waitretry=20 https://github.com/DiamondLightSource/ispyb-database/releases/download/v${{ env.DATABASE_SCHEMA }}/ispyb-database-${{ env.DATABASE_SCHEMA }}.tar.gz -O dist/ispyb-database.tar.gz
-      - name: Store artifact
+        run: wget -t 3 --waitretry=20 https://github.com/DiamondLightSource/ispyb-database/releases/download/v${{ env.DATABASE_SCHEMA }}/ispyb-database-${{ env.DATABASE_SCHEMA }}.tar.gz -O database/ispyb-database.tar.gz
+      - name: Store built package artifact
         uses: actions/upload-artifact@v4
         with:
           name: package-distributions
           path: dist/
+      - name: Store database artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: database
+          path: database/
       - name: Check package description
         run: python setup.py checkdocs
 

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Build python package
         run: python3 -m build
       - name: Download ISPyB DB schema v${{ env.DATABASE_SCHEMA }} for tests
-        run: wget -t 3 --waitretry=20 https://github.com/DiamondLightSource/ispyb-database/releases/download/v${{ env.DATABASE_SCHEMA }}/ispyb-database-${{ env.DATABASE_SCHEMA }}.tar.gz -O database/ispyb-database.tar.gz
+        run: |
+          mkdir database
+          wget -t 3 --waitretry=20 https://github.com/DiamondLightSource/ispyb-database/releases/download/v${{ env.DATABASE_SCHEMA }}/ispyb-database-${{ env.DATABASE_SCHEMA }}.tar.gz -O database/ispyb-database.tar.gz
       - name: Store built package artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1,4 +1,4 @@
-name: Run tests and publish Python distribution to PyPI
+name: Test & Publish
 
 on:
   [push, pull_request]
@@ -60,7 +60,7 @@ jobs:
           path: database/
 
   tests:
-    name: Call ci unit tests workflow
+    name: Testing
     uses: ./.github/workflows/ci.yml
     needs:
       - build
@@ -77,7 +77,7 @@ jobs:
       - run: echo "null"
 
   update_ORM:
-    name: Call orm update workflow
+    name: Update ORM
     permissions:
       contents: write
       pull-requests: write
@@ -90,8 +90,7 @@ jobs:
 
 
   publish-to-pypi:
-    name: >-
-      Publish Python distribution to PyPI
+    name: Publish PyPI
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
       - tests
@@ -112,9 +111,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
   github-release:
-    name: >-
-      Sign the Python distribution with Sigstore
-      and upload them to GitHub Release
+    name: Publish Github Release
     needs:
       - publish-to-pypi
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = ispyb
 version = 10.2.1
 description = Python package to access ISPyB database
-description-file = README.md
+description_file = README.md
 long_description = This package provides a Python interface to ISPyB. It can access the ISPyB database directly or (in future versions) run on top of the official ISPyB webservices API.
 author = Diamond Light Source
 author_email = scientificsoftware@diamond.ac.uk
@@ -21,7 +21,7 @@ classifiers =
 keywords =
 	ISPyB
 	database
-project-urls =
+project_urls =
 	Documentation = https://ispyb.readthedocs.io
 	GitHub = https://github.com/DiamondLightSource/ispyb-api
 	Bug-Tracker = https://github.com/DiamondLightSource/ispyb-api/issues


### PR DESCRIPTION
The previous version bump failed as it tried to upload the `ispyb-database` package to pypi.
This branch downloads the database into a `database/` folder from which it won't get uploaded.

I've also addressed a few other minor issues:
- Changed package build to use `python3 -m build`
- Fixed the codecov upload
- Changed dashes to underscores in the `setup.cfg` to fix warnings on build