### PR TITLE
Migration to sqlalchemy version 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        sqlalchemy-version: ["sqlalchemy==1.4", "sqlalchemy>=2,<3"]
     services:
       mariadb:
         image: mariadb:10.6
@@ -32,8 +33,7 @@ jobs:
       - name: Install package
         run: |
           set -eux
-          python -m pip install -r ./requirements_dev.txt
-          python -m pip install .
+          python -m pip install . -r ./requirements_dev.txt "${{ matrix.sqlalchemy-version }}"
 
       - name: Get database
         uses: actions/download-artifact@v4

--- a/.github/workflows/update-orm.yml
+++ b/.github/workflows/update-orm.yml
@@ -63,6 +63,7 @@ jobs:
           path: dist/
 
       - uses: shogo82148/actions-setup-mysql@v1
+        if: ${{ steps.checkUpdate.outputs.needsUpdate == 'true' }}
         with:
           distribution: 'mariadb'
           mysql-version: '10.6'

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,8 @@ History
 Unreleased / main
 -------------------
 
+* Compatibility with SQLAlchemy 2. SQLAlchemy 1.4 remains supported.
+
 10.2.0 (2024-08-14)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["ISPyB", "database"]
 requires-python = ">=3.7"
 readme = "README.md"
 license = { text = "Apache License 2.0" }
-dependencies = ["mysql-connector-python>=8.0.32", "sqlalchemy>=2,<3", "tabulate"]
+dependencies = ["mysql-connector-python>=8.0.32", "sqlalchemy>=1.4,<3", "tabulate"]
 
 [project.urls]
 Documentation = "https://ispyb.readthedocs.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["ISPyB", "database"]
 requires-python = ">=3.7"
 readme = "README.md"
 license = { text = "Apache License 2.0" }
-dependencies = ["mysql-connector-python>=8.0.32", "sqlalchemy>=2", "tabulate"]
+dependencies = ["mysql-connector-python>=8.0.32", "sqlalchemy>=2,<3", "tabulate"]
 
 [project.urls]
 Documentation = "https://ispyb.readthedocs.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["ISPyB", "database"]
 requires-python = ">=3.7"
 readme = "README.md"
 license = { text = "Apache License 2.0" }
-dependencies = ["mysql-connector-python>=8.0.32", "sqlalchemy<2", "tabulate"]
+dependencies = ["mysql-connector-python>=8.0.32", "sqlalchemy>=2", "tabulate"]
 
 [project.urls]
 Documentation = "https://ispyb.readthedocs.io"

--- a/requirements_orm.txt
+++ b/requirements_orm.txt
@@ -1,3 +1,3 @@
 mysql-connector-python>=8.0.32
 sqlacodegen<3
-sqlalchemy>=2
+sqlalchemy>=2,<3

--- a/requirements_orm.txt
+++ b/requirements_orm.txt
@@ -1,3 +1,3 @@
 mysql-connector-python>=8.0.32
 sqlacodegen<3
-sqlalchemy<2
+sqlalchemy>=2

--- a/src/ispyb/cli/last_data_collections_on.py
+++ b/src/ispyb/cli/last_data_collections_on.py
@@ -57,15 +57,15 @@ def get_last_data_collections_on(beamlines, db_session, limit=10, latest_dcid=No
         db_session.query(BLSession, DataCollection, GridInfo, Proposal)
         .options(
             Load(DataCollection).load_only(
-                "dataCollectionId",
-                "fileTemplate",
-                "imageDirectory",
-                "numberOfImages",
-                "startTime",
+                DataCollection.dataCollectionId,
+                DataCollection.fileTemplate,
+                DataCollection.imageDirectory,
+                DataCollection.numberOfImages,
+                DataCollection.startTime,
             ),
-            Load(Proposal).load_only("proposalCode", "proposalNumber"),
-            Load(BLSession).load_only("beamLineName", "visit_number"),
-            Load(GridInfo).load_only("steps_x", "steps_y"),
+            Load(Proposal).load_only(Proposal.proposalCode, Proposal.proposalNumber),
+            Load(BLSession).load_only(BLSession.beamLineName, BLSession.visit_number),
+            Load(GridInfo).load_only(GridInfo.steps_x, GridInfo.steps_y),
         )
         .join(
             BLSession,

--- a/src/ispyb/sqlalchemy/_auto_db_schema.py
+++ b/src/ispyb/sqlalchemy/_auto_db_schema.py
@@ -28,8 +28,7 @@ from sqlalchemy.dialects.mysql import (
     TINYINT,
     VARCHAR,
 )
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
 metadata = Base.metadata


### PR DESCRIPTION
This implements the minimum changes to update sqlalchemy to version 2.
I've currently set the requirement as `sqlalchemy>=2`, but it's possible this would still work in version 1.4

The breaking changes from earlier versions are:

- `declarative_base` has moved
- Table loads need to be attributes not strings

A more complete migration of the API query functions should be done in future, but the legacy methods still currently work.