### PR TITLE
Remove manual AutoProcScalingStatistics declaration

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,12 @@ History
 Unreleased / main
 -------------------
 
+11.0.2 (2025-03-13)
+-------------------
+
+* Replace manually declared accessors in table models with SQLAlchemy 2 compatible synonyms (in ProcessingJob, AutoProcProgramAttachment)
+* Remove manually declared accessors in AutoProcScaling
+
 11.0.1 (2025-03-11)
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ispyb"
-version = "11.0.1"
+version = "11.0.2"
 description = "Python package to access ISPyB database"
 authors = [
     { name = "Diamond Light Source", email = "scientificsoftware@diamond.ac.uk" },
@@ -59,7 +59,7 @@ unfixable = ["F841"]
 ignore = ["E501"]
 
 [tool.bumpversion]
-current_version = "11.0.1"
+current_version = "11.0.2"
 commit = true
 tag = true
 

--- a/src/ispyb/__init__.py
+++ b/src/ispyb/__init__.py
@@ -3,7 +3,7 @@ import logging
 import os
 import warnings
 
-__version__ = "11.0.1"
+__version__ = "11.0.2"
 
 _log = logging.getLogger("ispyb")
 

--- a/src/ispyb/sqlalchemy/__init__.py
+++ b/src/ispyb/sqlalchemy/__init__.py
@@ -23,11 +23,6 @@ AutoProcProgram.AutoProcProgramAttachments = relationship(
     back_populates="AutoProcProgram",
     overlaps="AutoProcProgramAttachment",
 )
-AutoProcScaling.AutoProcScalingStatistics = relationship(
-    "AutoProcScalingStatistics",
-    back_populates="AutoProcScaling",
-    overlaps="AutoProcScalingStatistics",
-)
 ProcessingJob.ProcessingJobParameters = relationship(
     "ProcessingJobParameter",
     back_populates="ProcessingJob",

--- a/src/ispyb/sqlalchemy/__init__.py
+++ b/src/ispyb/sqlalchemy/__init__.py
@@ -6,33 +6,21 @@ import warnings
 
 import sqlalchemy.engine
 import sqlalchemy.orm
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, synonym
 
 from ._auto_db_schema import *  # noqa F403; lgtm
 from ._auto_db_schema import (
     AutoProcProgram,
-    AutoProcScaling,
     ProcessingJob,
     __schema_version__,
 )
 
 logger = logging.getLogger("ispyb.sqlalchemy")
 
-AutoProcProgram.AutoProcProgramAttachments = relationship(
-    "AutoProcProgramAttachment",
-    back_populates="AutoProcProgram",
-    overlaps="AutoProcProgramAttachment",
-)
-ProcessingJob.ProcessingJobParameters = relationship(
-    "ProcessingJobParameter",
-    back_populates="ProcessingJob",
-    overlaps="ProcessingJobParameter",
-)
-ProcessingJob.ProcessingJobImageSweeps = relationship(
-    "ProcessingJobImageSweep",
-    back_populates="ProcessingJob",
-    overlaps="ProcessingJobImageSweep",
-)
+AutoProcProgram.AutoProcProgramAttachments = synonym("AutoProcProgramAttachment")
+ProcessingJob.ProcessingJobParameters = synonym("ProcessingJobParameter")
+ProcessingJob.ProcessingJobImageSweeps = synonym("ProcessingJobImageSweep")
+
 assert __schema_version__
 
 


### PR DESCRIPTION
Since this is already being declared as an autogenerated ORM model, we do not need to declare it again. Doing so triggers a deprecation warning, and may cause undefined behaviour in future versions of SQLAlchemy.

This fixes https://github.com/DiamondLightSource/ispyb-api/issues/233