### PR TITLE
Pin MySQL connector version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["ISPyB", "database"]
 requires-python = ">=3.10"
 readme = "README.md"
 license = { text = "Apache License 2.0" }
-dependencies = ["mysql-connector-python>=8.0.32", "sqlalchemy>=2,<3", "tabulate"]
+dependencies = ["mysql-connector-python~=9.5.0", "sqlalchemy>=2,<3", "tabulate"]
 
 [project.urls]
 Documentation = "https://ispyb.readthedocs.io"


### PR DESCRIPTION
This is because of a faulty update that omits CPython binary wheels for Python >3.11 https://bugs.mysql.com/bug.php?id=119736

I decided to pin this to a specific minor version, as this would be the safest way to go moving forward